### PR TITLE
feat: add marketplace module with escrow payments

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,8 @@ import propertyRoutes from './routes/property.routes';
 import contractRoutes from './routes/contract.routes';
 import userRoutes from './routes/user.routes';
 import adminRoutes from './routes/admin.routes';
+import proRoutes from './routes/pro.routes';
+import ticketRoutes from './routes/ticket.routes';
 
 // Load environment variables
 dotenv.config();
@@ -25,6 +27,8 @@ app.use('/api/contracts', contractRoutes);
 app.use('/api/users', userRoutes);
 // Admin functionality
 app.use('/api/admin', adminRoutes);
+app.use('/api', proRoutes);
+app.use('/api/tickets', ticketRoutes);
 
 const PORT = process.env.PORT || 3000;
 

--- a/src/models/escrow.model.ts
+++ b/src/models/escrow.model.ts
@@ -1,0 +1,22 @@
+import { Schema, model, Document } from 'mongoose';
+export interface IEscrow extends Document {
+  contractId: string;
+  ticketId: string;
+  amount: number;
+  currency: 'EUR';
+  status: 'held'|'released'|'disputed';
+  ledger: { ts: Date; type: 'hold'|'release'|'dispute'; payload?: any }[];
+  provider: 'stripe'|'mock';
+  paymentRef?: string; // Stripe PaymentIntent id o mock ref
+}
+const s = new Schema<IEscrow>({
+  contractId: { type: String, required: true },
+  ticketId: { type: String, required: true },
+  amount: { type: Number, required: true },
+  currency: { type: String, default: 'EUR' },
+  status: { type: String, default: 'held' },
+  ledger: [{ ts: Date, type: String, payload: Schema.Types.Mixed }],
+  provider: { type: String, default: 'mock' },
+  paymentRef: String
+},{timestamps:true});
+export default model<IEscrow>('Escrow', s);

--- a/src/models/pro.model.ts
+++ b/src/models/pro.model.ts
@@ -1,0 +1,23 @@
+import { Schema, model, Document } from 'mongoose';
+export type ProService = 'plumbing'|'electricity'|'appliances'|'locksmith'|'cleaning'|'painting'|'others';
+export interface IPro extends Document {
+  userId: string;
+  displayName: string;
+  city: string;
+  services: { key: ProService; basePrice?: number }[];
+  ratingAvg: number;
+  jobsDone: number;
+  verified: boolean;
+  active: boolean;
+}
+const s = new Schema<IPro>({
+  userId: { type: String, index: true, unique: true },
+  displayName: { type: String, required: true },
+  city: { type: String, required: true },
+  services: [{ key: String, basePrice: Number }],
+  ratingAvg: { type: Number, default: 0 },
+  jobsDone: { type: Number, default: 0 },
+  verified: { type: Boolean, default: false },
+  active: { type: Boolean, default: true },
+},{timestamps:true});
+export default model<IPro>('Pro', s);

--- a/src/models/ticket.model.ts
+++ b/src/models/ticket.model.ts
@@ -1,0 +1,34 @@
+import { Schema, model, Document } from 'mongoose';
+export interface ITicket extends Document {
+  contractId: string;
+  propertyId?: string;
+  openedBy: string;  // tenant
+  ownerId: string;   // landlord
+  proId?: string;    // assigned pro
+  service: string;
+  title: string;
+  description: string;
+  status: 'open'|'quoted'|'in_progress'|'awaiting_validation'|'closed'|'disputed';
+  quote?: { amount: number; currency: 'EUR'; proId: string; ts: Date };
+  extra?: { amount: number; reason: string; status: 'pending'|'approved'|'rejected' };
+  invoiceUrl?: string;
+  history: { ts: Date; actor: string; action: string; payload?: any }[];
+  escrowId?: string;
+}
+const s = new Schema<ITicket>({
+  contractId: { type: String, required: true },
+  propertyId: String,
+  openedBy: { type: String, required: true },
+  ownerId: { type: String, required: true },
+  proId: String,
+  service: { type: String, required: true },
+  title: { type: String, required: true },
+  description: { type: String, required: true },
+  status: { type: String, default: 'open' },
+  quote: { amount: Number, currency: String, proId: String, ts: Date },
+  extra: { amount: Number, reason: String, status: String },
+  invoiceUrl: String,
+  history: [{ ts: Date, actor: String, action: String, payload: Schema.Types.Mixed }],
+  escrowId: String
+},{timestamps:true});
+export default model<ITicket>('Ticket', s);

--- a/src/routes/pro.routes.ts
+++ b/src/routes/pro.routes.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import Pro from '../models/pro.model';
+import { getUserId } from '../utils/getUserId';
+const r = Router();
+
+// Alta/edición PRO del usuario autenticado
+r.post('/pros', async (req, res) => {
+  const userId = getUserId(req);
+  const { displayName, city, services, verified } = req.body || {};
+  const pro = await Pro.findOneAndUpdate(
+    { userId },
+    { $set: { displayName, city, services, verified: !!verified, active: true } },
+    { new: true, upsert: true }
+  );
+  res.status(201).json(pro);
+});
+
+// Listado con filtros
+r.get('/pros', async (req, res) => {
+  const { service, city, page = 1, limit = 10 } = req.query as any;
+  const q: any = { active: true };
+  if (service) q['services.key'] = service;
+  if (city) q.city = new RegExp(`^${city}$`, 'i');
+  const items = await Pro.find(q).sort({ ratingAvg: -1, jobsDone: -1 })
+    .skip((+page - 1) * +limit).limit(+limit);
+  const total = await Pro.countDocuments(q);
+  res.json({ items, total, page: +page, limit: +limit });
+});
+export default r;

--- a/src/routes/ticket.routes.ts
+++ b/src/routes/ticket.routes.ts
@@ -1,0 +1,115 @@
+import { Router } from 'express';
+import Ticket from '../models/ticket.model';
+import Escrow from '../models/escrow.model';
+import { getUserId } from '../utils/getUserId';
+import { holdPayment, releasePayment } from '../utils/payment';
+const r = Router();
+
+r.get('/ping', (_req, res) => res.json({ ok: true }));
+
+// 1) Inquilino abre incidencia
+r.post('/', async (req, res) => {
+  const userId = getUserId(req);
+  const { contractId, ownerId, propertyId, service, title, description } = req.body || {};
+  const t = await Ticket.create({
+    contractId, ownerId, propertyId, openedBy: userId, service, title, description,
+    status: 'open', history: [{ ts: new Date(), actor: userId, action: 'opened' }]
+  });
+  res.status(201).json(t);
+});
+
+// 2) Profesional envía presupuesto
+r.post('/:id/quote', async (req, res) => {
+  const userId = getUserId(req);
+  const { amount } = req.body || {};
+  const t = await Ticket.findById(req.params.id);
+  if (!t) return res.status(404).json({ error: 'not found' });
+  t.quote = { amount: Number(amount), currency: 'EUR', proId: userId, ts: new Date() };
+  t.proId = userId; t.status = 'quoted';
+  t.history.push({ ts: new Date(), actor: userId, action: 'quoted', payload: { amount: Number(amount) } });
+  await t.save();
+  res.json(t);
+});
+
+// 3) Propietario aprueba → hold (escrow)
+r.post('/:id/approve', async (req, res) => {
+  const userId = getUserId(req);
+  const t = await Ticket.findById(req.params.id);
+  if (!t?.quote) return res.status(400).json({ error: 'quote required' });
+  const { customerId } = req.body as { customerId?: string };
+  if (!customerId) return res.status(400).json({ error: 'customerId (Stripe) is required' });
+
+  const pay = await holdPayment({ customerId, amount: t.quote.amount, currency: 'eur', meta: { ticketId: String(t._id) } });
+
+  const esc = await Escrow.create({
+    contractId: t.contractId, ticketId: String(t._id), amount: t.quote.amount,
+    currency: 'EUR', status: 'held', provider: pay.provider, paymentRef: pay.ref,
+    ledger: [{ ts: new Date(), type: 'hold', payload: pay }]
+  });
+
+  t.escrowId = String(esc._id); t.status = 'in_progress';
+  t.history.push({ ts: new Date(), actor: userId, action: 'approved_quote', payload: { escrowId: String(esc._id) } });
+  await t.save();
+  res.json({ ticket: t, escrow: esc });
+});
+
+// 4) Profesional solicita EXTRA
+r.post('/:id/extra', async (req, res) => {
+  const userId = getUserId(req);
+  const { amount, reason } = req.body || {};
+  const t = await Ticket.findById(req.params.id);
+  if (!t) return res.status(404).json({ error: 'not found' });
+  t.extra = { amount: Number(amount), reason, status: 'pending' };
+  t.history.push({ ts: new Date(), actor: userId, action: 'extra_requested', payload: { amount: Number(amount), reason } });
+  await t.save();
+  res.json(t);
+});
+
+// 5) Propietario decide EXTRA
+r.post('/:id/extra/decide', async (req, res) => {
+  const userId = getUserId(req);
+  const { approve } = req.body || {};
+  const t = await Ticket.findById(req.params.id);
+  if (!t?.extra) return res.status(400).json({ error: 'no extra pending' });
+  t.extra.status = approve ? 'approved' : 'rejected';
+  t.history.push({ ts: new Date(), actor: userId, action: approve ? 'extra_approved' : 'extra_rejected' });
+  await t.save();
+  res.json(t);
+});
+
+// 6) Profesional completa + factura
+r.post('/:id/complete', async (req, res) => {
+  const userId = getUserId(req);
+  const { invoiceUrl } = req.body || {};
+  const t = await Ticket.findById(req.params.id);
+  if (!t) return res.status(404).json({ error: 'not found' });
+  t.invoiceUrl = invoiceUrl;
+  t.status = 'awaiting_validation';
+  t.history.push({ ts: new Date(), actor: userId, action: 'completed', payload: { invoiceUrl } });
+  await t.save();
+  res.json(t);
+});
+
+// 7) Propietario valida → release (escrow)
+r.post('/:id/validate', async (req, res) => {
+  const userId = getUserId(req);
+  const t = await Ticket.findById(req.params.id);
+  if (!t?.escrowId) return res.status(400).json({ error: 'no escrow' });
+  const esc = await Escrow.findById(t.escrowId);
+  if (!esc) return res.status(404).json({ error: 'escrow not found' });
+
+  const total = (t.quote?.amount ?? 0) + ((t.extra && t.extra.status === 'approved') ? t.extra.amount : 0);
+  await releasePayment({ ref: esc.paymentRef!, amount: total, currency: 'eur' });
+
+  esc.status = 'released';
+  esc.ledger.push({ ts: new Date(), type: 'release', payload: { amount: total } });
+  await esc.save();
+
+  t.status = 'closed';
+  t.history.push({ ts: new Date(), actor: userId, action: 'validated_and_released', payload: { total } });
+  await t.save();
+
+  res.json({ ticket: t, escrow: esc });
+});
+
+export default r;

--- a/src/utils/getUserId.ts
+++ b/src/utils/getUserId.ts
@@ -1,0 +1,8 @@
+import { Request } from 'express';
+
+/**
+ * Retrieves the user ID from the `x-user-id` header. Returns an empty string if not present.
+ */
+export function getUserId(req: Request): string {
+  return String(req.headers['x-user-id'] || '');
+}


### PR DESCRIPTION
## Summary
- add Pro, Ticket, and Escrow models for marketplace
- implement professional and ticket routes with escrow logic
- extend payment utilities with hold and release wrappers and integrate routes in app

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa05e15154832aba7c6cb87e924e20