### PR TITLE
feat: add professional module and ticket integration

### DIFF
--- a/docs/examples.http
+++ b/docs/examples.http
@@ -1,0 +1,46 @@
+### Crear/editar PRO
+POST http://localhost:3000/api/pros
+Content-Type: application/json
+x-user-id: PRO1
+
+{
+  "displayName": "Manitas SL",
+  "city": "A Coruña",
+  "services": [
+    { "key": "plumbing", "basePrice": 50 },
+    { "key": "locksmith", "basePrice": 40 }
+  ],
+  "verified": true
+}
+
+### Ver mi PRO
+GET http://localhost:3000/api/pros/me
+x-user-id: PRO1
+
+### Listar PROs
+GET http://localhost:3000/api/pros?service=plumbing&city=A%20Coru%C3%B1a&page=1&limit=10
+
+### Asignar PRO a ticket
+POST http://localhost:3000/api/tickets/{{TICKET_ID}}/assign
+Content-Type: application/json
+x-user-id: L1
+
+{
+  "proId": "{{PRO_OBJECT_ID}}"
+}
+
+### Desasignar PRO de ticket
+POST http://localhost:3000/api/tickets/{{TICKET_ID}}/unassign
+x-user-id: L1
+
+### Tickets por inquilino
+GET http://localhost:3000/api/tickets/my/tenant
+x-user-id: T1
+
+### Tickets por propietario
+GET http://localhost:3000/api/tickets/my/owner
+x-user-id: L1
+
+### Tickets por profesional
+GET http://localhost:3000/api/tickets/my/pro
+x-user-id: PRO1

--- a/src/models/pro.model.ts
+++ b/src/models/pro.model.ts
@@ -1,5 +1,13 @@
 import { Schema, model, Document } from 'mongoose';
-export type ProService = 'plumbing'|'electricity'|'appliances'|'locksmith'|'cleaning'|'painting'|'others';
+
+export type ProService =
+  | 'plumbing'
+  | 'electricity'
+  | 'appliances'
+  | 'locksmith'
+  | 'cleaning'
+  | 'painting'
+  | 'others';
 export interface IPro extends Document {
   userId: string;
   displayName: string;
@@ -10,14 +18,21 @@ export interface IPro extends Document {
   verified: boolean;
   active: boolean;
 }
+
+const serviceSchema = new Schema<{ key: ProService; basePrice?: number }>({
+  key: { type: String, enum: ['plumbing', 'electricity', 'appliances', 'locksmith', 'cleaning', 'painting', 'others'], required: true },
+  basePrice: Number,
+}, { _id: false });
+
 const s = new Schema<IPro>({
-  userId: { type: String, index: true, unique: true },
+  userId: { type: String, required: true, unique: true, index: true },
   displayName: { type: String, required: true },
-  city: { type: String, required: true },
-  services: [{ key: String, basePrice: Number }],
+  city: { type: String, required: true, index: true },
+  services: [serviceSchema],
   ratingAvg: { type: Number, default: 0 },
   jobsDone: { type: Number, default: 0 },
   verified: { type: Boolean, default: false },
   active: { type: Boolean, default: true },
 },{timestamps:true});
+s.index({ 'services.key': 1 });
 export default model<IPro>('Pro', s);

--- a/src/routes/pro.routes.ts
+++ b/src/routes/pro.routes.ts
@@ -1,29 +1,68 @@
 import { Router } from 'express';
 import Pro from '../models/pro.model';
 import { getUserId } from '../utils/getUserId';
+
 const r = Router();
 
 // Alta/edición PRO del usuario autenticado
 r.post('/pros', async (req, res) => {
-  const userId = getUserId(req);
-  const { displayName, city, services, verified } = req.body || {};
-  const pro = await Pro.findOneAndUpdate(
-    { userId },
-    { $set: { displayName, city, services, verified: !!verified, active: true } },
-    { new: true, upsert: true }
-  );
-  res.status(201).json(pro);
+  try {
+    const userId = getUserId(req);
+    const { displayName, city, services = [], verified } = req.body || {};
+    if (!displayName || !city) {
+      return res.status(400).json({ error: 'displayName and city are required', code: 400 });
+    }
+    const pro = await Pro.findOneAndUpdate(
+      { userId },
+      { $set: { displayName, city, services, verified: !!verified, active: true } },
+      { new: true, upsert: true, runValidators: true }
+    );
+    res.status(201).json(pro);
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
 
-// Listado con filtros
-r.get('/pros', async (req, res) => {
-  const { service, city, page = 1, limit = 10 } = req.query as any;
-  const q: any = { active: true };
-  if (service) q['services.key'] = service;
-  if (city) q.city = new RegExp(`^${city}$`, 'i');
-  const items = await Pro.find(q).sort({ ratingAvg: -1, jobsDone: -1 })
-    .skip((+page - 1) * +limit).limit(+limit);
-  const total = await Pro.countDocuments(q);
-  res.json({ items, total, page: +page, limit: +limit });
+// Obtener mi perfil PRO
+r.get('/pros/me', async (req, res) => {
+  try {
+    const userId = getUserId(req);
+    const pro = await Pro.findOne({ userId });
+    if (!pro) return res.status(404).json({ error: 'not found', code: 404 });
+    res.json(pro);
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
+
+// Listado con filtros y paginación
+r.get('/pros', async (req, res) => {
+  try {
+    const { service, city } = req.query as any;
+    let page = Math.max(1, parseInt((req.query.page as string) || '1'));
+    let limit = Math.min(50, Math.max(1, parseInt((req.query.limit as string) || '10')));
+    const q: any = { active: true };
+    if (service) q['services.key'] = service;
+    if (city) q.city = new RegExp(`^${city}$`, 'i');
+    const [items, total] = await Promise.all([
+      Pro.find(q).sort({ ratingAvg: -1, jobsDone: -1 }).skip((page - 1) * limit).limit(limit),
+      Pro.countDocuments(q)
+    ]);
+    res.json({ items, total, page, limit });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
+});
+
+// Obtener PRO por id
+r.get('/pros/:id', async (req, res) => {
+  try {
+    const pro = await Pro.findById(req.params.id);
+    if (!pro) return res.status(404).json({ error: 'not found', code: 404 });
+    res.json(pro);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message, code: 500 });
+  }
+});
+
 export default r;

--- a/src/routes/ticket.routes.ts
+++ b/src/routes/ticket.routes.ts
@@ -1,115 +1,250 @@
 import { Router } from 'express';
 import Ticket from '../models/ticket.model';
 import Escrow from '../models/escrow.model';
+import Pro from '../models/pro.model';
 import { getUserId } from '../utils/getUserId';
 import { holdPayment, releasePayment } from '../utils/payment';
+
 const r = Router();
+
+function parsePagination(query: any) {
+  const page = Math.max(1, parseInt(query.page as string) || 1);
+  const limit = Math.min(50, Math.max(1, parseInt(query.limit as string) || 10));
+  return { page, limit };
+}
 
 r.get('/ping', (_req, res) => res.json({ ok: true }));
 
 // 1) Inquilino abre incidencia
 r.post('/', async (req, res) => {
-  const userId = getUserId(req);
-  const { contractId, ownerId, propertyId, service, title, description } = req.body || {};
-  const t = await Ticket.create({
-    contractId, ownerId, propertyId, openedBy: userId, service, title, description,
-    status: 'open', history: [{ ts: new Date(), actor: userId, action: 'opened' }]
-  });
-  res.status(201).json(t);
+  try {
+    const userId = getUserId(req);
+    const { contractId, ownerId, propertyId, service, title, description } = req.body || {};
+    const t = await Ticket.create({
+      contractId,
+      ownerId,
+      propertyId,
+      openedBy: userId,
+      service,
+      title,
+      description,
+      status: 'open',
+      history: [{ ts: new Date(), actor: userId, action: 'opened' }]
+    });
+    res.status(201).json(t);
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
 
 // 2) Profesional envía presupuesto
 r.post('/:id/quote', async (req, res) => {
-  const userId = getUserId(req);
-  const { amount } = req.body || {};
-  const t = await Ticket.findById(req.params.id);
-  if (!t) return res.status(404).json({ error: 'not found' });
-  t.quote = { amount: Number(amount), currency: 'EUR', proId: userId, ts: new Date() };
-  t.proId = userId; t.status = 'quoted';
-  t.history.push({ ts: new Date(), actor: userId, action: 'quoted', payload: { amount: Number(amount) } });
-  await t.save();
-  res.json(t);
+  try {
+    const userId = getUserId(req);
+    const { amount } = req.body || {};
+    const t = await Ticket.findById(req.params.id);
+    if (!t) return res.status(404).json({ error: 'not found', code: 404 });
+    t.quote = { amount: Number(amount), currency: 'EUR', proId: userId, ts: new Date() };
+    t.proId = userId;
+    t.status = 'quoted';
+    t.history.push({ ts: new Date(), actor: userId, action: 'quoted', payload: { amount: Number(amount) } });
+    await t.save();
+    res.json(t);
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
 
 // 3) Propietario aprueba → hold (escrow)
 r.post('/:id/approve', async (req, res) => {
-  const userId = getUserId(req);
-  const t = await Ticket.findById(req.params.id);
-  if (!t?.quote) return res.status(400).json({ error: 'quote required' });
-  const { customerId } = req.body as { customerId?: string };
-  if (!customerId) return res.status(400).json({ error: 'customerId (Stripe) is required' });
+  try {
+    const userId = getUserId(req);
+    const t = await Ticket.findById(req.params.id);
+    if (!t?.quote) return res.status(400).json({ error: 'quote required', code: 400 });
+    const { customerId } = req.body as { customerId?: string };
+    if (!customerId) return res.status(400).json({ error: 'customerId (Stripe) is required', code: 400 });
 
-  const pay = await holdPayment({ customerId, amount: t.quote.amount, currency: 'eur', meta: { ticketId: String(t._id) } });
+    const pay = await holdPayment({ customerId, amount: t.quote.amount, currency: 'eur', meta: { ticketId: String(t._id) } });
 
-  const esc = await Escrow.create({
-    contractId: t.contractId, ticketId: String(t._id), amount: t.quote.amount,
-    currency: 'EUR', status: 'held', provider: pay.provider, paymentRef: pay.ref,
-    ledger: [{ ts: new Date(), type: 'hold', payload: pay }]
-  });
+    const esc = await Escrow.create({
+      contractId: t.contractId, ticketId: String(t._id), amount: t.quote.amount,
+      currency: 'EUR', status: 'held', provider: pay.provider, paymentRef: pay.ref,
+      ledger: [{ ts: new Date(), type: 'hold', payload: pay }]
+    });
 
-  t.escrowId = String(esc._id); t.status = 'in_progress';
-  t.history.push({ ts: new Date(), actor: userId, action: 'approved_quote', payload: { escrowId: String(esc._id) } });
-  await t.save();
-  res.json({ ticket: t, escrow: esc });
+    t.escrowId = String(esc._id);
+    t.status = 'in_progress';
+    t.history.push({ ts: new Date(), actor: userId, action: 'approved_quote', payload: { escrowId: String(esc._id) } });
+    await t.save();
+    res.json({ ticket: t, escrow: esc });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
 
 // 4) Profesional solicita EXTRA
 r.post('/:id/extra', async (req, res) => {
-  const userId = getUserId(req);
-  const { amount, reason } = req.body || {};
-  const t = await Ticket.findById(req.params.id);
-  if (!t) return res.status(404).json({ error: 'not found' });
-  t.extra = { amount: Number(amount), reason, status: 'pending' };
-  t.history.push({ ts: new Date(), actor: userId, action: 'extra_requested', payload: { amount: Number(amount), reason } });
-  await t.save();
-  res.json(t);
+  try {
+    const userId = getUserId(req);
+    const { amount, reason } = req.body || {};
+    const t = await Ticket.findById(req.params.id);
+    if (!t) return res.status(404).json({ error: 'not found', code: 404 });
+    t.extra = { amount: Number(amount), reason, status: 'pending' };
+    t.history.push({ ts: new Date(), actor: userId, action: 'extra_requested', payload: { amount: Number(amount), reason } });
+    await t.save();
+    res.json(t);
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
 
 // 5) Propietario decide EXTRA
 r.post('/:id/extra/decide', async (req, res) => {
-  const userId = getUserId(req);
-  const { approve } = req.body || {};
-  const t = await Ticket.findById(req.params.id);
-  if (!t?.extra) return res.status(400).json({ error: 'no extra pending' });
-  t.extra.status = approve ? 'approved' : 'rejected';
-  t.history.push({ ts: new Date(), actor: userId, action: approve ? 'extra_approved' : 'extra_rejected' });
-  await t.save();
-  res.json(t);
+  try {
+    const userId = getUserId(req);
+    const { approve } = req.body || {};
+    const t = await Ticket.findById(req.params.id);
+    if (!t?.extra) return res.status(400).json({ error: 'no extra pending', code: 400 });
+    t.extra.status = approve ? 'approved' : 'rejected';
+    t.history.push({ ts: new Date(), actor: userId, action: approve ? 'extra_approved' : 'extra_rejected' });
+    await t.save();
+    res.json(t);
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
 
 // 6) Profesional completa + factura
 r.post('/:id/complete', async (req, res) => {
-  const userId = getUserId(req);
-  const { invoiceUrl } = req.body || {};
-  const t = await Ticket.findById(req.params.id);
-  if (!t) return res.status(404).json({ error: 'not found' });
-  t.invoiceUrl = invoiceUrl;
-  t.status = 'awaiting_validation';
-  t.history.push({ ts: new Date(), actor: userId, action: 'completed', payload: { invoiceUrl } });
-  await t.save();
-  res.json(t);
+  try {
+    const userId = getUserId(req);
+    const { invoiceUrl } = req.body || {};
+    const t = await Ticket.findById(req.params.id);
+    if (!t) return res.status(404).json({ error: 'not found', code: 404 });
+    t.invoiceUrl = invoiceUrl;
+    t.status = 'awaiting_validation';
+    t.history.push({ ts: new Date(), actor: userId, action: 'completed', payload: { invoiceUrl } });
+    await t.save();
+    res.json(t);
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
 
 // 7) Propietario valida → release (escrow)
 r.post('/:id/validate', async (req, res) => {
-  const userId = getUserId(req);
-  const t = await Ticket.findById(req.params.id);
-  if (!t?.escrowId) return res.status(400).json({ error: 'no escrow' });
-  const esc = await Escrow.findById(t.escrowId);
-  if (!esc) return res.status(404).json({ error: 'escrow not found' });
+  try {
+    const userId = getUserId(req);
+    const t = await Ticket.findById(req.params.id);
+    if (!t?.escrowId) return res.status(400).json({ error: 'no escrow', code: 400 });
+    const esc = await Escrow.findById(t.escrowId);
+    if (!esc) return res.status(404).json({ error: 'escrow not found', code: 404 });
 
-  const total = (t.quote?.amount ?? 0) + ((t.extra && t.extra.status === 'approved') ? t.extra.amount : 0);
-  await releasePayment({ ref: esc.paymentRef!, amount: total, currency: 'eur' });
+    const total = (t.quote?.amount ?? 0) + ((t.extra && t.extra.status === 'approved') ? t.extra.amount : 0);
+    await releasePayment({ ref: esc.paymentRef!, amount: total, currency: 'eur' });
 
-  esc.status = 'released';
-  esc.ledger.push({ ts: new Date(), type: 'release', payload: { amount: total } });
-  await esc.save();
+    esc.status = 'released';
+    esc.ledger.push({ ts: new Date(), type: 'release', payload: { amount: total } });
+    await esc.save();
 
-  t.status = 'closed';
-  t.history.push({ ts: new Date(), actor: userId, action: 'validated_and_released', payload: { total } });
-  await t.save();
+    t.status = 'closed';
+    t.history.push({ ts: new Date(), actor: userId, action: 'validated_and_released', payload: { total } });
+    await t.save();
 
-  res.json({ ticket: t, escrow: esc });
+    res.json({ ticket: t, escrow: esc });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
+});
+
+// 8) Asignar profesional a un ticket
+r.post('/:id/assign', async (req, res) => {
+  try {
+    const userId = getUserId(req);
+    const { proId } = req.body || {};
+    if (!proId) return res.status(400).json({ error: 'proId required', code: 400 });
+    const ticket = await Ticket.findById(req.params.id);
+    if (!ticket) return res.status(404).json({ error: 'ticket not found', code: 404 });
+    const pro = await Pro.findById(proId);
+    if (!pro || !pro.active) return res.status(404).json({ error: 'pro not found', code: 404 });
+    if (ticket.proId && ticket.proId !== pro.userId) {
+      return res.status(409).json({ error: 'ticket already assigned', code: 409 });
+    }
+    ticket.proId = pro.userId;
+    ticket.history.push({ ts: new Date(), actor: userId, action: 'assigned_pro', payload: { proId } });
+    await ticket.save();
+    res.json({ ticket });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
+});
+
+// 9) Desasignar profesional
+r.post('/:id/unassign', async (req, res) => {
+  try {
+    const userId = getUserId(req);
+    const ticket = await Ticket.findById(req.params.id);
+    if (!ticket) return res.status(404).json({ error: 'ticket not found', code: 404 });
+    if (!ticket.proId) return res.status(400).json({ error: 'ticket has no pro assigned', code: 400 });
+    ticket.proId = undefined;
+    ticket.history.push({ ts: new Date(), actor: userId, action: 'unassigned_pro' });
+    await ticket.save();
+    res.json({ ticket });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
+});
+
+// Listados de tickets por rol
+r.get('/my/tenant', async (req, res) => {
+  try {
+    const userId = getUserId(req);
+    const { status } = req.query as any;
+    const { page, limit } = parsePagination(req.query);
+    const q: any = { openedBy: userId };
+    if (status) q.status = status;
+    const [items, total] = await Promise.all([
+      Ticket.find(q).sort({ createdAt: -1 }).skip((page - 1) * limit).limit(limit),
+      Ticket.countDocuments(q)
+    ]);
+    res.json({ items, total, page, limit });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
+});
+
+r.get('/my/owner', async (req, res) => {
+  try {
+    const userId = getUserId(req);
+    const { status } = req.query as any;
+    const { page, limit } = parsePagination(req.query);
+    const q: any = { ownerId: userId };
+    if (status) q.status = status;
+    const [items, total] = await Promise.all([
+      Ticket.find(q).sort({ createdAt: -1 }).skip((page - 1) * limit).limit(limit),
+      Ticket.countDocuments(q)
+    ]);
+    res.json({ items, total, page, limit });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
+});
+
+r.get('/my/pro', async (req, res) => {
+  try {
+    const userId = getUserId(req);
+    const { status } = req.query as any;
+    const { page, limit } = parsePagination(req.query);
+    const q: any = { proId: userId };
+    if (status) q.status = status;
+    const [items, total] = await Promise.all([
+      Ticket.find(q).sort({ createdAt: -1 }).skip((page - 1) * limit).limit(limit),
+      Ticket.countDocuments(q)
+    ]);
+    res.json({ items, total, page, limit });
+  } catch (err: any) {
+    res.status(err.status || 500).json({ error: err.message, code: err.status || 500 });
+  }
 });
 
 export default r;

--- a/src/utils/getUserId.ts
+++ b/src/utils/getUserId.ts
@@ -1,8 +1,11 @@
 import { Request } from 'express';
 
 /**
- * Retrieves the user ID from the `x-user-id` header. Returns an empty string if not present.
+ * Retrieves the user ID from the `x-user-id` header.
+ * Throws a 400 error if the header is missing.
  */
 export function getUserId(req: Request): string {
-  return String(req.headers['x-user-id'] || '');
+  const uid = req.header('x-user-id');
+  if (!uid) throw Object.assign(new Error('Missing x-user-id'), { status: 400 });
+  return String(uid);
 }


### PR DESCRIPTION
## Summary
- implement Professional model with services enum, indices and defaults
- add CRUD and listing routes for pros with validation and pagination
- integrate ticket assignment, unassignment and role-based listings
- enforce x-user-id header via helper and document curl examples

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa31158dac832a8939610afb1ac19c