### PR TITLE
Refactor global styles into scoped modules

### DIFF
--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,0 +1,23 @@
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+}
+
+.container {
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+.layoutBody {
+  display: flex;
+}
+
+.main {
+  flex: 1;
+  padding: 16px;
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,19 +3,20 @@ import Sidebar from './Sidebar';
 import NavBar from './NavBar';
 import Breadcrumbs from './Breadcrumbs';
 import Footer from './Footer';
+import styles from './Layout.module.css';
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <div>
-      <div className="navbar">
-        <div className="container">
+      <div className={styles.navbar}>
+        <div className={styles.container}>
           <NavBar />
         </div>
       </div>
-      <div style={{ display: 'flex' }}>
+      <div className={styles.layoutBody}>
         <Sidebar />
-        <main style={{ flex: 1, padding: 16 }}>
-          <div className="container">
+        <main className={styles.main}>
+          <div className={styles.container}>
             <Breadcrumbs />
             {children}
           </div>

--- a/frontend/src/components/NavBar.module.css
+++ b/frontend/src/components/NavBar.module.css
@@ -1,0 +1,57 @@
+.inner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  text-decoration: none;
+  color: inherit;
+  margin-right: 16px;
+}
+
+.logo {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
+.links {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.link {
+  padding: 6px 10px;
+  border-radius: 8px;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.linkActive {
+  box-shadow: inset 0 -2px 0 0 var(--fg);
+}
+
+.spacer {
+  margin-left: auto;
+}
+
+.iconButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
+import styles from './NavBar.module.css';
 
 const NavBar: React.FC = () => {
   const navigate = useNavigate();
@@ -14,35 +15,38 @@ const NavBar: React.FC = () => {
   };
 
   const logoSrc = `${process.env.PUBLIC_URL || ''}/rental-logo.png`;
-  const linkClass = ({ isActive }: any) => `nav-link${isActive ? ' active' : ''}`;
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    `${styles.link}${isActive ? ` ${styles.linkActive}` : ''}`;
   return (
-    <nav className="navbar-inner">
-      <Link to="/" className="nav-brand">
+    <nav className={styles.inner}>
+      <Link to="/" className={styles.brand}>
         <img
           src={logoSrc}
           alt="Rental"
           onError={(e: any) => { e.currentTarget.src = `${process.env.PUBLIC_URL || ''}/logo512.png`; }}
-          className="nav-logo"
+          className={styles.logo}
         />
         <span>Rental</span>
       </Link>
-      <div className="nav-links">
+      <div className={styles.links}>
         <NavLink to="/" className={linkClass}>Propiedades</NavLink>
         <NavLink to="/dashboard" className={linkClass}>Dashboard</NavLink>
       </div>
-      <div className="nav-spacer" />
+      <div className={styles.spacer} />
       {user && (
-        <span className="muted" style={{ marginRight: 12 }}>
+        <span style={{ marginRight: 12, color: 'var(--muted)' }}>
           Rol: <b>{user.role}</b>
         </span>
       )}
-      <button onClick={toggle} className="btn-icon" aria-label="toggle theme" style={{ marginRight: 8 }}>
+      <button onClick={toggle} className={styles.iconButton} aria-label="toggle theme" style={{ marginRight: 8 }}>
         {theme === 'light' ? '🌙' : '☀️'}
       </button>
       {!token ? (
-        <NavLink to="/login" className="nav-link">Login</NavLink>
+        <NavLink to="/login" className={linkClass}>Login</NavLink>
       ) : (
-        <button onClick={handleLogout} className="nav-link btn-icon" style={{ padding: '6px 10px' }}>Salir</button>
+        <button onClick={handleLogout} className={`${styles.link} ${styles.iconButton}`} style={{ padding: '6px 10px' }}>
+          Salir
+        </button>
       )}
     </nav>
   );

--- a/frontend/src/components/ui/Drawer.module.css
+++ b/frontend/src/components/ui/Drawer.module.css
@@ -1,0 +1,19 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(2px);
+  z-index: 40;
+}
+
+.panel {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  background: var(--card);
+  border-right: 1px solid var(--border);
+  z-index: 50;
+  transition: transform 0.25s ease;
+  padding: 16px;
+  overflow-y: auto;
+}

--- a/frontend/src/components/ui/Drawer.tsx
+++ b/frontend/src/components/ui/Drawer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import styles from './Drawer.module.css';
 
 type Props = {
   open: boolean;
@@ -26,9 +27,9 @@ const Drawer: React.FC<Props> = ({ open, onClose, side='left', children, width=3
   const shadowStyle = side === 'right' ? { boxShadow: '-12px 0 24px rgba(0,0,0,.08)' } : { boxShadow: '12px 0 24px rgba(0,0,0,.08)' };
   return (
     <>
-      {open && <div className="drawer-backdrop" onClick={onClose} />}
+      {open && <div className={styles.backdrop} onClick={onClose} />}
       <div
-        className="drawer-panel"
+        className={styles.panel}
         style={{
           width: `min(${width}px, 92vw)`,
           transform: open ? 'translateX(0)' : side==='left' ? 'translateX(-100%)' : 'translateX(100%)',

--- a/frontend/src/components/ui/Gallery.module.css
+++ b/frontend/src/components/ui/Gallery.module.css
@@ -1,0 +1,50 @@
+.empty {
+  height: 320px;
+  background: #f5f5f5;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  color: #888;
+}
+
+.main {
+  height: 320px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.thumbs {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  overflow-x: auto;
+}
+
+.thumbButton {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0;
+  background: transparent;
+}
+
+.thumbButtonActive {
+  border-width: 2px;
+  border-color: var(--primary);
+}
+
+.thumbImage {
+  width: 64px;
+  height: 48px;
+  object-fit: cover;
+  display: block;
+  border-radius: 6px;
+}

--- a/frontend/src/components/ui/Gallery.tsx
+++ b/frontend/src/components/ui/Gallery.tsx
@@ -1,23 +1,28 @@
 import React, { useState } from 'react';
 import { toAbsoluteUrl } from '../../utils/media';
+import styles from './Gallery.module.css';
 
 const Gallery: React.FC<{ photos?: string[] }>= ({ photos }) => {
   const imgs = (photos || []).filter(Boolean);
   const [i, setI] = useState(0);
   if (imgs.length === 0) return (
-    <div className="gallery-empty">Sin foto</div>
+    <div className={styles.empty}>Sin foto</div>
   );
   const current = imgs[Math.max(0, Math.min(i, imgs.length - 1))];
   return (
     <div>
-      <div className="gallery-main">
-        <img src={toAbsoluteUrl(current)} alt="foto" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+      <div className={styles.main}>
+        <img src={toAbsoluteUrl(current)} alt="foto" className={styles.image} />
       </div>
       {imgs.length > 1 && (
-        <div className="gallery-thumbs">
+        <div className={styles.thumbs}>
           {imgs.map((src, idx) => (
-            <button key={src+idx} onClick={() => setI(idx)} className={`thumb-btn${idx===i?' active':''}`}>
-              <img src={toAbsoluteUrl(src)} alt={`thumb-${idx}`} style={{ width: 64, height: 48, objectFit: 'cover', display: 'block', borderRadius: 6 }} />
+            <button
+              key={src+idx}
+              onClick={() => setI(idx)}
+              className={`${styles.thumbButton}${idx===i ? ` ${styles.thumbButtonActive}` : ''}`}
+            >
+              <img src={toAbsoluteUrl(src)} alt={`thumb-${idx}`} className={styles.thumbImage} />
             </button>
           ))}
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,8 +15,8 @@
   --primary: #4f46e5;
   --primary-hover: #4338ca;
   --border: #e2e8f0;
-  --primary-rgb: 79, 70, 229; /* Añadido para sombras */
-  --primary-hover-rgb: 67, 56, 202; /* Añadido para sombras */
+  --primary-rgb: 79, 70, 229;
+  --primary-hover-rgb: 67, 56, 202;
 }
 
 html[data-theme='dark'] {
@@ -27,248 +27,33 @@ html[data-theme='dark'] {
   --primary: #818cf8;
   --primary-hover: #6366f1;
   --border: #1f2937;
-  --primary-rgb: 129, 140, 248; /* Añadido para sombras */
-  --primary-hover-rgb: 99, 102, 241; /* Añadido para sombras */
+  --primary-rgb: 129, 140, 248;
+  --primary-hover-rgb: 99, 102, 241;
 }
 
 body {
   margin: 0;
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, 'Apple Color Emoji', 'Segoe UI Emoji';
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: var(--bg); /* Usar variable CSS para el fondo */
+  background: var(--bg);
   color: var(--fg);
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
-/* Links y botones focus/hover */
 a {
   color: inherit;
 }
+
 a:hover {
   opacity: 0.85;
 }
-button:focus, a:focus {
+
+button:focus,
+a:focus {
   outline: 2px solid var(--primary);
   outline-offset: 2px;
-}
-
-/* Layout helpers */
-.container {
-  max-width: 1200px;
-  width: 100%;
-  margin: 0 auto;
-  padding: 0 16px;
-}
-
-.navbar {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
-}
-.navbar-inner {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 0;
-}
-.nav-brand {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-weight: 700;
-  text-decoration: none;
-  color: inherit;
-  margin-right: 16px;
-}
-.nav-logo {
-  width: 28px; height: 28px; object-fit: contain;
-}
-.nav-links {
-  display: flex; gap: 12px; align-items: center;
-}
-.nav-link { padding: 6px 10px; border-radius: 8px; text-decoration: none; text-transform: uppercase; letter-spacing: .06em; font-weight: 500; }
-.nav-link.active { box-shadow: inset 0 -2px 0 0 var(--fg); }
-.nav-spacer { margin-left: auto; }
-.btn-icon { background: none; border: none; cursor: pointer; font-size: 16px; } /* Duplicado con .btn, revisar */
-
-/* Cards and grids */
-.grid-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 20px; }
-.grid-detail { display: grid; grid-template-columns: 2fr 1fr; gap: 24px; }
-.card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; } /* Duplicado con .container, revisar */
-.card-minimal { background: transparent; border: none; border-radius: 0; }
-.card-body { padding: 12px; }
-.card-media { height: 140px; background: #f5f5f5; display: flex; align-items: center; justify-content: center; color: #999; overflow: hidden; } /* Color fijo, revisar */
-.card-media img { transition: transform .35s ease; }
-.card:hover .card-media img { transform: scale(1.03); }
-.card .card-media .hover-second { opacity: 0; }
-.card:hover .card-media .hover-second { opacity: 1; }
-.muted { color: var(--muted); }
-.price { margin-top: 8px; font-weight: 600; letter-spacing: .03em; }
-
-/* Gallery */
-.gallery-main { height: 320px; border-radius: 12px; overflow: hidden; border: 1px solid var(--border); } /* Duplicado con .card, revisar */
-.gallery-empty { height: 320px; background: #f5f5f5; border-radius: 12px; border: 1px solid var(--border); display: grid; place-items: center; color: #888; } /* Color fijo, revisar */
-.gallery-thumbs { display: flex; gap: 8px; margin-top: 8px; overflow-x: auto; }
-.thumb-btn { border: 1px solid var(--border); border-radius: 8px; padding: 0; background: transparent; }
-.thumb-btn.active { border: 2px solid var(--primary); }
-
-/* Forms */
-.form-row { display: flex; gap: 12px; margin: 8px 0 16px; flex-wrap: wrap; }
-.input-sm { width: 120px; }
-
-/* Utilities */
-.page-title { margin: 0 0 12px; }
-.divider { height: 1px; background: var(--border); margin: 12px 0; }
-
-/* Links */
-.link { text-decoration: none; position: relative; }
-.link-underline::after { content: ''; position: absolute; left: 0; right: 0; bottom: -2px; height: 1px; background: currentColor; opacity: .6; transition: opacity .2s ease; } /* Duplicado con .nav-link, revisar */
-.link-underline:hover::after { opacity: 1; }
-
-/* Drawer */
-.drawer-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.25); backdrop-filter: blur(2px); z-index: 40; }
-.drawer-panel { position: fixed; top: 0; bottom: 0; background: var(--card); border-right: 1px solid var(--border); z-index: 50; transition: transform .25s ease; padding: 16px; overflow-y: auto; }
-
-/* Badges */
-.badge { display: inline-block; padding: 2px 6px; border-radius: 6px; font-size: 11px; letter-spacing: .06em; text-transform: uppercase; border: 1px solid var(--border); background: var(--card); } /* Duplicado con .card, revisar */
-
-/* Responsive */
-@media (max-width: 900px) {
-  .grid-detail { grid-template-columns: 1fr; }
-}
-
-/* Estilos de style.css adaptados */
-.login-wrapper {
-  min-height: 100vh;
-  background: linear-gradient(135deg, #7fc5ee, #785fd1); /* Mantener el degradado para esta página */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 20px;
-}
-
-.login-container {
-  background: var(--card); /* Usar variable CSS */
-  backdrop-filter: blur(10px);
-  padding: 40px 35px;
-  border-radius: 15px;
-  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.2);
-  width: 100%;
-  max-width: 400px; /* Mantener max-width */
-  transition: transform 0.3s ease;
-}
-
-.login-container:hover {
-  transform: translateY(-5px);
-}
-
-.form-box h1 {
-  font-weight: 600;
-  font-size: 2.3rem;
-  color: var(--fg); /* Usar variable CSS */
-  margin-bottom: 30px;
-  text-align: center;
-}
-
-.input-box {
-  position: relative;
-  margin-bottom: 25px;
-}
-
-.input-box input {
-  width: 100%;
-  padding: 14px 45px 14px 15px;
-  border-radius: 8px;
-  border: 1.5px solid var(--border); /* Usar variable CSS */
-  font-size: 1rem;
-  outline: none;
-  transition: border-color 0.3s ease;
-}
-
-.input-box input:focus {
-  border-color: var(--primary); /* Usar variable CSS */
-  box-shadow: 0 0 5px rgba(var(--primary-rgb), 0.5); /* Usar variable CSS */
-}
-
-.input-box i {
-  position: absolute;
-  right: 15px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--muted); /* Usar variable CSS */
-  font-size: 1.3rem;
-  pointer-events: none;
-}
-
-.forgot-link {
-  text-align: right;
-  margin-bottom: 25px;
-}
-
-.forgot-link a {
-  font-size: 0.9rem;
-  color: var(--primary); /* Usar variable CSS */
-  text-decoration: none;
-  transition: color 0.3s ease;
-}
-
-.forgot-link a:hover {
-  color: var(--primary-hover); /* Usar variable CSS */
-  text-decoration: underline;
-}
-
-.btn-form {
-  width: 100%;
-  padding: 15px;
-  background: var(--primary); /* Usar variable CSS */
-  color: white;
-  font-weight: 600;
-  font-size: 1.1rem;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-  box-shadow: 0 5px 15px rgba(var(--primary-rgb), 0.5); /* Adaptar a variable CSS */
-  transition: background-color 0.3s ease, box-shadow 0.3s ease;
-}
-
-.btn-form:hover {
-  background: var(--primary-hover); /* Usar variable CSS */
-  box-shadow: 0 8px 20px rgba(var(--primary-hover-rgb), 0.6); /* Adaptar a variable CSS */
-}
-
-p.form-text {
-  text-align: center;
-  margin: 20px 0 15px;
-  font-size: 1rem;
-  color: var(--fg); /* Usar variable CSS */
-}
-
-.social-icons {
-  display: flex;
-  justify-content: center;
-  gap: 20px;
-}
-
-.social-icons a {
-  font-size: 1.8rem;
-  color: var(--primary); /* Usar variable CSS */
-  transition: color 0.3s ease;
-}
-
-.social-icons a:hover {
-  color: var(--primary-hover); /* Usar variable CSS */
-}
-
-/* Error message */
-form p[style] {
-  margin-top: 10px;
-  font-weight: 600;
-  font-size: 0.95rem;
 }

--- a/frontend/src/pages/ContractDetail.tsx
+++ b/frontend/src/pages/ContractDetail.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../context/AuthContext';
 import Button from '../components/ui/Button';
 import Card from '../components/ui/Card';
 import { useToast } from '../context/ToastContext';
+import pageStyles from './Page.module.css';
 
 const ContractDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -43,7 +44,7 @@ const ContractDetail: React.FC = () => {
 
   return (
     <div>
-      <h1 className="page-title">Detalle del Contrato</h1>
+      <h1 className={pageStyles.title}>Detalle del Contrato</h1>
       <Card style={{ padding: 24 }}>
         <p>ID: {c._id || c.id}</p>
         <p>Inquilino: {c.tenant?.id || c.tenant}</p>

--- a/frontend/src/pages/Page.module.css
+++ b/frontend/src/pages/Page.module.css
@@ -1,0 +1,3 @@
+.title {
+  margin: 0 0 12px;
+}

--- a/frontend/src/pages/PropertyDetail.module.css
+++ b/frontend/src/pages/PropertyDetail.module.css
@@ -1,0 +1,11 @@
+.grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 900px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/PropertyDetail.tsx
+++ b/frontend/src/pages/PropertyDetail.tsx
@@ -12,6 +12,8 @@ import Alert from '../components/ui/Alert';
 import { useToast } from '../context/ToastContext';
 import Gallery from '../components/ui/Gallery';
 import { useDocumentTitle } from '../utils/useDocumentTitle';
+import pageStyles from './Page.module.css';
+import styles from './PropertyDetail.module.css';
 
 type Params = { id: string };
 
@@ -101,13 +103,13 @@ const PropertyDetail: React.FC = () => {
 
   if (loading) return (
     <div>
-      <h1 className="page-title">Cargando propiedad…</h1>
-      <div className="grid-detail">
+      <h1 className={pageStyles.title}>Cargando propiedad…</h1>
+      <div className={styles.grid}>
         <div>
-          <div className="gallery-empty" />
-          <div className="card" style={{ marginTop: 12, height: 120 }} />
+          <div style={{ height: 320, borderRadius: 12, border: '1px solid var(--border)', background: '#f5f5f5', display: 'grid', placeItems: 'center', color: '#888' }} />
+          <div style={{ background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 12, marginTop: 12, height: 120 }} />
         </div>
-        <div className="card" style={{ height: 280 }} />
+        <div style={{ background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 12, height: 280 }} />
       </div>
     </div>
   );
@@ -116,13 +118,13 @@ const PropertyDetail: React.FC = () => {
   const stripePkMissing = !process.env.REACT_APP_STRIPE_PK;
   return (
     <div>
-      <h1 className="page-title">{property.title}</h1>
-      <div className="grid-detail">
+      <h1 className={pageStyles.title}>{property.title}</h1>
+      <div className={styles.grid}>
         <div>
           <Gallery photos={property.photos} />
           <Card style={{ padding: 16, marginTop: 12 }}>
-            <p className="muted">{property.address}</p>
-            <div className="price" style={{ fontSize: 20 }}>{formatPriceEUR(property.price)}</div>
+            <p style={{ color: 'var(--muted)' }}>{property.address}</p>
+            <div style={{ marginTop: 8, fontWeight: 600, letterSpacing: '.03em', fontSize: 20 }}>{formatPriceEUR(property.price)}</div>
             {property.description && <p style={{ marginTop: 8 }}>{property.description}</p>}
           </Card>
         </div>

--- a/frontend/src/pages/PropertyList.module.css
+++ b/frontend/src/pages/PropertyList.module.css
@@ -1,0 +1,120 @@
+.filtersRow {
+  display: flex;
+  gap: 12px;
+  margin: 8px 0 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.cardMedia {
+  position: relative;
+  height: 140px;
+  background: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  overflow: hidden;
+}
+
+.mediaInner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.mediaImage {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.35s ease, opacity 0.25s ease;
+}
+
+.hoverSecond {
+  opacity: 0;
+}
+
+.card:hover .mediaImage {
+  transform: scale(1.03);
+}
+
+.card:hover .hoverSecond {
+  opacity: 1;
+}
+
+.cardBody {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.price {
+  margin-top: 8px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.link {
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+}
+
+.linkUnderline::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+}
+
+.linkUnderline:hover::after {
+  opacity: 1;
+}
+
+.iconButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.inputSmall {
+  width: 120px;
+}
+
+.publishLink {
+  padding: 6px 10px;
+  border-radius: 8px;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 500;
+  color: inherit;
+  border: 1px solid var(--border);
+  background: transparent;
+}

--- a/frontend/src/pages/PropertyList.tsx
+++ b/frontend/src/pages/PropertyList.tsx
@@ -5,12 +5,13 @@ import { useAuth } from '../context/AuthContext';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import { SkeletonCard } from '../components/ui/Skeleton';
-import Pagination from '../components/ui/Pagination';
 import { isFavorite, toggleFavorite } from '../utils/favorites';
 import { toAbsoluteUrl } from '../utils/media';
 import Drawer from '../components/ui/Drawer';
 import Badge from '../components/ui/Badge';
 import { formatPriceEUR, isNew } from '../utils/format';
+import pageStyles from './Page.module.css';
+import styles from './PropertyList.module.css';
 
 const PropertyList: React.FC = () => {
   const [properties, setProperties] = useState<any[]>([]);
@@ -20,7 +21,6 @@ const PropertyList: React.FC = () => {
   const [max, setMax] = useState('');
   const [favTick, setFavTick] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [page, setPage] = useState(1);
   const pageSize = 12;
   const [visible, setVisible] = useState(pageSize);
   const [showFilters, setShowFilters] = useState(false);
@@ -48,7 +48,7 @@ const PropertyList: React.FC = () => {
       return 0;
     });
     return out;
-  }, [properties, q, min, max]);
+  }, [properties, q, min, max, sort]);
 
   useEffect(() => { setVisible(pageSize); }, [q, min, max, sort]);
   useEffect(() => {
@@ -65,8 +65,8 @@ const PropertyList: React.FC = () => {
   const pageItems = filtered.slice(0, visible);
   return (
     <div>
-      <h1 className="page-title">Propiedades</h1>
-      <div className="form-row">
+      <h1 className={pageStyles.title}>Propiedades</h1>
+      <div className={styles.filtersRow}>
         <Button variant="outline" onClick={() => setShowFilters(true)}>Filtros</Button>
         <select value={sort} onChange={e => setSort(e.target.value as any)} style={{ border: '1px solid var(--border)', background: 'var(--card)', color: 'var(--fg)', borderRadius: 8, padding: '10px 12px' }}>
           <option value="relevant">Relevancia</option>
@@ -75,10 +75,10 @@ const PropertyList: React.FC = () => {
           <option value="newest">Novedades</option>
           <option value="oldest">Más antiguas</option>
         </select>
-        {user?.role === 'landlord' && <Link to="/dashboard" className="nav-link" style={{ marginLeft: 'auto' }}>Publicar</Link>}
+        {user?.role === 'landlord' && <Link to="/dashboard" className={styles.publishLink} style={{ marginLeft: 'auto' }}>Publicar</Link>}
       </div>
       {loading ? (
-        <div className="grid-cards">
+        <div className={styles.cardGrid}>
           {Array.from({ length: 8 }).map((_, i) => (
             <SkeletonCard key={i} />
           ))}
@@ -92,15 +92,27 @@ const PropertyList: React.FC = () => {
           </p>
         </div>
       ) : (
-        <div className="grid-cards">
+        <div className={styles.cardGrid}>
           {pageItems.map(p => (
-            <div key={p._id} className="card card-minimal">
-              <div className="card-media">
+            <div key={p._id} className={styles.card}>
+              <div className={styles.cardMedia}>
                 {p.photos?.[0] ? (
-                  <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-                    <img loading="lazy" decoding="async" src={toAbsoluteUrl(p.photos[0])} alt={p.title} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover', transition: 'opacity .25s ease' }} />
+                  <div className={styles.mediaInner}>
+                    <img
+                      loading="lazy"
+                      decoding="async"
+                      src={toAbsoluteUrl(p.photos[0])}
+                      alt={p.title}
+                      className={styles.mediaImage}
+                    />
                     {p.photos?.[1] && (
-                      <img loading="lazy" decoding="async" src={toAbsoluteUrl(p.photos[1])} alt={p.title} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover', opacity: 0, transition: 'opacity .25s ease' }} className="hover-second" />
+                      <img
+                        loading="lazy"
+                        decoding="async"
+                        src={toAbsoluteUrl(p.photos[1])}
+                        alt={p.title}
+                        className={`${styles.mediaImage} ${styles.hoverSecond}`}
+                      />
                     )}
                   </div>
                 ) : 'Sin foto'}
@@ -110,13 +122,18 @@ const PropertyList: React.FC = () => {
                   </div>
                 )}
               </div>
-              <div className="card-body">
+              <div className={styles.cardBody}>
                 <h3 style={{ margin: '6px 0 4px', textTransform: 'uppercase', letterSpacing: '.06em', fontSize: 14 }}>{p.title}</h3>
-                <div className="muted" style={{ fontSize: 14 }}>{p.address}</div>
-                <div className="price">{formatPriceEUR(p.price)}</div>
+                <div style={{ fontSize: 14, color: 'var(--muted)' }}>{p.address}</div>
+                <div className={styles.price}>{formatPriceEUR(p.price)}</div>
                 <div style={{ marginTop: 12, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <Link to={`/p/${p._id}`} className="link link-underline">Ver detalle</Link>
-                  <button aria-label="favorito" onClick={() => { toggleFavorite(String(p._id)); setFavTick(x=>x+1); }} className="btn-icon" style={{ fontSize: 18 }}>
+                  <Link to={`/p/${p._id}`} className={`${styles.link} ${styles.linkUnderline}`}>Ver detalle</Link>
+                  <button
+                    aria-label="favorito"
+                    onClick={() => { toggleFavorite(String(p._id)); setFavTick(x=>x+1); }}
+                    className={styles.iconButton}
+                    style={{ fontSize: 18 }}
+                  >
                     {isFavorite(String(p._id)) ? '❤' : '♡'}
                   </button>
                 </div>
@@ -129,11 +146,11 @@ const PropertyList: React.FC = () => {
       {/* Drawer de filtros */}
       <Drawer open={showFilters} onClose={() => setShowFilters(false)} side="right">
         <h3 style={{ marginTop: 0 }}>Filtros</h3>
-        <div className="form-row" style={{ flexDirection: 'column' }}>
+        <div className={styles.filtersRow} style={{ flexDirection: 'column' }}>
           <Input placeholder="Buscar..." value={q} onChange={e => setQ(e.target.value)} />
           <div style={{ display: 'flex', gap: 12 }}>
-            <Input placeholder="Min €" value={min} onChange={e => setMin(e.target.value)} className="input-sm" />
-            <Input placeholder="Max €" value={max} onChange={e => setMax(e.target.value)} className="input-sm" />
+            <Input placeholder="Min €" value={min} onChange={e => setMin(e.target.value)} className={styles.inputSmall} />
+            <Input placeholder="Max €" value={max} onChange={e => setMax(e.target.value)} className={styles.inputSmall} />
           </div>
           <div>
             <Button variant="primary" onClick={() => setShowFilters(false)}>Aplicar</Button>


### PR DESCRIPTION
## Summary
- move layout, navigation, drawer, and gallery styling into local CSS modules that components import directly
- trim `index.css` down to shared variables, reset, and focus states while adding a reusable page title module
- update property list/detail pages to rely on the new modules and preserve visual treatments for cards and galleries

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68c87d2bf0cc832a8655d2974c4600f6