### PR TITLE
Add contract creation workflow with PDF generation and hashing

### DIFF
--- a/scripts/migrate_contracts_v1.ts
+++ b/scripts/migrate_contracts_v1.ts
@@ -1,0 +1,27 @@
+import mongoose from "mongoose";
+import { Contract } from "../src/models/contract.model";
+
+async function run() {
+  if (!process.env.MONGO_URL) {
+    throw new Error("MONGO_URL no definido");
+  }
+  await mongoose.connect(process.env.MONGO_URL);
+
+  await Contract.updateMany(
+    { clausePolicyVersion: { $exists: false } },
+    { $set: { clausePolicyVersion: "1.0.0" } }
+  );
+
+  await Contract.updateMany(
+    { status: { $exists: false } },
+    { $set: { status: "pending_signature" } }
+  );
+
+  console.log("Migration done");
+  await mongoose.disconnect();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/policies/clauses/index.ts
+++ b/src/policies/clauses/index.ts
@@ -1,0 +1,27 @@
+import { CLAUSES_BASE, CLAUSES_BY_REGION, type ClauseDefinition, type RegionKey } from "./catalog.v1";
+
+export type ClauseCatalogByRegion = Record<string, ClauseDefinition>;
+
+function normalizeRegion(region: string): string {
+  return region.trim().toLowerCase();
+}
+
+export function getCatalogByRegion(region: string): ClauseCatalogByRegion | null {
+  if (!region || typeof region !== "string") {
+    return null;
+  }
+  const normalized = normalizeRegion(region);
+  const regionalCatalog =
+    normalized === "general"
+      ? {}
+      : CLAUSES_BY_REGION[normalized as RegionKey] ?? null;
+
+  if (normalized !== "general" && regionalCatalog === null) {
+    return null;
+  }
+
+  return {
+    ...CLAUSES_BASE,
+    ...(regionalCatalog ?? {}),
+  };
+}

--- a/src/routes/contract.routes.ts
+++ b/src/routes/contract.routes.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 import * as contractController from '../controllers/contract.controller';
 import { authenticate } from '../middleware/auth.middleware';
-import { validateContract } from '../middleware/validation.middleware';
 
 const router = Router();
 
@@ -9,7 +8,7 @@ const router = Router();
 router.get('/', authenticate, contractController.listContracts);
 
 // Crear contrato
-router.post('/', authenticate, validateContract, contractController.createContract);
+router.post('/', authenticate, contractController.create);
 
 // Descargar contrato en PDF
 router.get('/:id/pdf', authenticate, contractController.getContractPDF);

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,17 +1,76 @@
-import { ContractHistory } from '../models/history.model';
+import { Types } from "mongoose";
+import { Contract } from "../models/contract.model";
+import { ContractHistory } from "../models/history.model";
 
-/**
- * Append a history entry for a contract. Use this helper whenever the
- * contract's state changes (creation, signature, payment, etc.).
- */
-export const recordContractHistory = async (
-  contractId: string,
+type ActorLike = string | Types.ObjectId | null | undefined;
+
+type DetailsLike = Record<string, unknown> | null | undefined;
+
+const normalizeActorId = (value: ActorLike): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  if (value instanceof Types.ObjectId) {
+    return value.toHexString();
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    return value;
+  }
+  return undefined;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+};
+
+export async function recordContractHistory(
+  contractId: string | Types.ObjectId,
   action: string,
-  description?: string,
-) => {
+  actorOrDetails?: ActorLike | DetailsLike,
+  maybeDetails?: DetailsLike,
+): Promise<void> {
+  let actorId: string | undefined;
+  let payload: Record<string, unknown> = {};
+
+  if (maybeDetails !== undefined) {
+    actorId = normalizeActorId(actorOrDetails as ActorLike);
+    if (isPlainObject(maybeDetails)) {
+      payload = maybeDetails;
+    }
+  } else if (isPlainObject(actorOrDetails) && !(actorOrDetails instanceof Types.ObjectId)) {
+    payload = actorOrDetails as Record<string, unknown>;
+  } else if (actorOrDetails instanceof Types.ObjectId) {
+    actorId = normalizeActorId(actorOrDetails);
+  } else if (typeof actorOrDetails === "string") {
+    payload = { message: actorOrDetails };
+  }
+
+  const entry = {
+    ts: new Date(),
+    actorId,
+    action,
+    payload,
+  };
+
   try {
+    await Contract.findByIdAndUpdate(
+      contractId,
+      { $push: { history: entry } },
+      { new: false },
+    );
+  } catch (error) {
+    console.error("Error actualizando historial embebido del contrato:", error);
+  }
+
+  try {
+    const description =
+      typeof payload.message === "string"
+        ? payload.message
+        : typeof actorOrDetails === "string" && maybeDetails === undefined
+          ? actorOrDetails
+          : undefined;
     await new ContractHistory({ contract: contractId, action, description }).save();
   } catch (error) {
-    console.error('Error al registrar historial del contrato:', error);
+    console.error("Error al registrar historial del contrato:", error);
   }
-};
+}

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -1,92 +1,104 @@
-import PDFDocument from 'pdfkit';
+import fs from "fs";
+import path from "path";
+import PDFDocument from "pdfkit";
 
-/**
- * Data passed to the PDF generator to render a tenancy agreement. All
- * strings are expected to be present and any optional data should be
- * converted to empty strings upstream to avoid runtime errors.
- */
-interface ContractData {
-  landlordName: string;
-  landlordDNI: string;
-  landlordAddress: string;
-  tenantName: string;
-  tenantDNI: string;
-  tenantAddress: string;
-  propertyAddress: string;
-  cadastralRef: string;
-  durationMonths: number;
-  startDate: string;
-  endDate: string;
-  monthlyRent: number;
-  deposit: number;
-  paymentDay: number;
-  bankAccount: string;
-  city: string;
-  dateSigned: string;
+interface GenerateContractPDFOptions {
+  contract: {
+    _id?: unknown;
+    id?: unknown;
+    landlord?: unknown;
+    tenant?: unknown;
+    property?: unknown;
+    region?: string;
+    rent?: number;
+    deposit?: number;
+    startDate?: Date | string;
+    endDate?: Date | string;
+  };
+  clausesText: string[];
 }
 
-export const generateContractPDF = (data: ContractData): Buffer => {
-  const doc = new PDFDocument({ size: 'A4', margin: 50 });
-  const buffers: Uint8Array[] = [];
-  doc.on('data', buffers.push.bind(buffers));
-  doc.on('end', () => {});
+export interface GenerateContractPDFResult {
+  absolutePath: string;
+  publicPath: string;
+}
 
-  // Title
-  doc.fontSize(18).text('CONTRATO DE ARRENDAMIENTO DE VIVIENDA', { align: 'center' });
+const CONTRACTS_UPLOAD_DIR = path.join(process.cwd(), "uploads", "contracts");
+
+const formatDate = (value: Date | string | undefined): string => {
+  if (!value) {
+    return "";
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toISOString().split("T")[0];
+};
+
+const ensureDirectory = async (dir: string) => {
+  await fs.promises.mkdir(dir, { recursive: true });
+};
+
+export async function generateContractPDF({
+  contract,
+  clausesText,
+}: GenerateContractPDFOptions): Promise<GenerateContractPDFResult> {
+  await ensureDirectory(CONTRACTS_UPLOAD_DIR);
+  const contractId = String(contract._id ?? contract.id ?? "contract");
+  const filename = `${contractId}.pdf`;
+  const absolutePath = path.join(CONTRACTS_UPLOAD_DIR, filename);
+  const publicPath = `/uploads/contracts/${filename}`;
+
+  const doc = new PDFDocument({ size: "A4", margin: 50 });
+  const writeStream = fs.createWriteStream(absolutePath);
+  const finished = new Promise<void>((resolve, reject) => {
+    writeStream.on("finish", resolve);
+    writeStream.on("error", reject);
+  });
+
+  doc.pipe(writeStream);
+
+  const generationDate = formatDate(new Date());
+  doc.fontSize(18).text("CONTRATO DE ARRENDAMIENTO DE VIVIENDA", { align: "center" });
   doc.moveDown(0.5);
-  doc.fontSize(10).text(`En ${data.city}, a ${data.dateSigned}`, { align: 'right' });
+  doc.fontSize(10).text(`Generado el ${generationDate}`, { align: "right" });
   doc.moveDown(1);
 
-  // Parties introduction
-  doc.fontSize(12).text('REUNIDOS', { underline: true });
+  doc.fontSize(12).text("DATOS DEL CONTRATO", { underline: true });
   doc.moveDown(0.5);
-  doc
-    .fontSize(10)
-    .text(`Arrendador: ${data.landlordName}, DNI ${data.landlordDNI}, domicilio en ${data.landlordAddress}.`)
-    .moveDown(0.3)
-    .text(`Inquilino: ${data.tenantName}, DNI ${data.tenantDNI}, domicilio en ${data.tenantAddress}.`);
-  doc.moveDown(1);
-
-  // Background
-  doc.fontSize(12).text('EXPONEN', { underline: true });
-  doc.moveDown(0.5);
-  doc.fontSize(10).text(
-    `Que el arrendador es titular de la vivienda sita en ${data.propertyAddress}, referencia catastral ${data.cadastralRef}, y desea ceder su uso al inquilino bajo las siguientes cláusulas:`,
+  doc.fontSize(10);
+  doc.text(`Arrendador (ID): ${String(contract.landlord ?? "-" )}`);
+  doc.text(`Inquilino (ID): ${String(contract.tenant ?? "-" )}`);
+  doc.text(`Propiedad (ID): ${String(contract.property ?? "-" )}`);
+  doc.text(`Región: ${contract.region ?? "-"}`);
+  doc.text(`Renta mensual: ${contract.rent ?? "-"} €`);
+  doc.text(`Depósito: ${contract.deposit ?? "-"} €`);
+  doc.text(
+    `Vigencia: ${formatDate(contract.startDate) || "-"} - ${formatDate(contract.endDate) || "-"}`,
   );
   doc.moveDown(1);
 
-  // Clauses
-  doc.fontSize(12).text('CLÁUSULAS', { underline: true });
-  const clauses = [
-    `1. Objeto: uso y disfrute de la vivienda descrita.`,
-    `2. Duración: ${data.durationMonths} meses, desde ${data.startDate} hasta ${data.endDate}.`,
-    `3. Renta: €${data.monthlyRent} mensuales, pagaderos antes del día ${data.paymentDay} de cada mes mediante transferencia a la cuenta ${data.bankAccount}.`,
-    `4. Fianza: €${data.deposit}, entregada en este acto conforme al artículo 36 LAU.`,
-    `5. Gastos: suministros y comunidad a cargo del inquilino.`,
-    `6. Conservación: reparaciones menores por el inquilino; mayores por el arrendador.`,
-    `7. Obras: no se podrán realizar sin autorización escrita del arrendador.`,
-    `8. Subarriendo: prohibido sin consentimiento expreso.`,
-    `9. Inventario: se adjunta como Anexo I.`,
-    `10. Anexos:`,
-  ];
-  // Write clauses
-  doc.moveDown(0.5).fontSize(10);
-  clauses.forEach(text => {
-    doc.text(text).moveDown(0.3);
-  });
-  // Annex section
+  doc.fontSize(12).text("CLÁUSULAS", { underline: true });
   doc.moveDown(0.5);
-  doc.fontSize(10).text('- Anexo I: Inventario de muebles y enseres');
-  doc.text('- Anexo II: Certificado de eficiencia energética');
-  doc.text('- Anexo III: Cédula de habitabilidad');
-  doc.moveDown(1);
-  // Signatures
+  if (clausesText.length === 0) {
+    doc.fontSize(10).text("No se han proporcionado cláusulas adicionales.");
+  } else {
+    clausesText.forEach((text, index) => {
+      doc.fontSize(10).text(`${index + 1}. ${text}`).moveDown(0.5);
+    });
+  }
+
   doc.moveDown(2);
-  const sigY = doc.y;
-  doc.text('__________________________', 80, sigY);
-  doc.text('__________________________', 350, sigY);
-  doc.text(`Arrendador: ${data.landlordName}`, 80, sigY + 15);
-  doc.text(`Inquilino: ${data.tenantName}`, 350, sigY + 15);
+  const signatureY = doc.y;
+  doc.fontSize(10);
+  doc.text("__________________________", 80, signatureY);
+  doc.text("__________________________", 320, signatureY);
+  doc.text("Arrendador", 80, signatureY + 15);
+  doc.text("Inquilino", 320, signatureY + 15);
+
   doc.end();
-  return Buffer.concat(buffers);
-};
+  await finished;
+
+  return { absolutePath, publicPath };
+}

--- a/src/utils/pdfHash.ts
+++ b/src/utils/pdfHash.ts
@@ -1,0 +1,16 @@
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+
+function resolveAbsolutePath(filePath: string): string {
+  if (path.isAbsolute(filePath)) {
+    return filePath;
+  }
+  return path.join(process.cwd(), filePath);
+}
+
+export function computePdfHash(filePath: string): string {
+  const absolutePath = resolveAbsolutePath(filePath);
+  const buffer = fs.readFileSync(absolutePath);
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}

--- a/tests/contracts/create-contract.test.ts
+++ b/tests/contracts/create-contract.test.ts
@@ -1,0 +1,32 @@
+import request from "supertest";
+import { app } from "../../src/app";
+import { connectDb, disconnectDb, clearDb } from "../utils/db";
+
+describe("POST /api/contracts", () => {
+  beforeAll(connectDb);
+  afterAll(disconnectDb);
+  afterEach(clearDb);
+
+  it("crea contrato y genera pdfHash", async () => {
+    const payload = {
+      landlord: "507f1f77bcf86cd799439011",
+      tenant: "507f1f77bcf86cd799439012",
+      property: "507f1f77bcf86cd799439013",
+      region: "galicia",
+      rent: 750,
+      deposit: 750,
+      startDate: "2025-10-01",
+      endDate: "2026-09-30",
+      clauses: [
+        { id: "duracion_prorroga", params: { mesesIniciales: 12, mesesProrroga: 12 } },
+        { id: "fianza_autonomica", params: {} }
+      ]
+    };
+
+    const res = await request(app).post("/api/contracts").send(payload).expect(201);
+
+    expect(res.body.contract.region).toBe("galicia");
+    expect(res.body.contract.pdfHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(typeof res.body.contract.pdfPath).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary
- implement a new contract creation controller that validates input with Zod, normalizes clauses, generates the PDF/hash, and records history entries
- extend the contract schema plus supporting utilities to store clause policy version, PDF metadata, and embedded history while updating the signature flow
- add clause catalog helper, PDF hash utility, migration script, and a regression test covering PDF hash generation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b28dd8f0832aaf2cc9580f343073