### PR TITLE
feat: add clauses catalog endpoint and frontend usage

### DIFF
--- a/frontend/src/pages/contracts/ClausesStep.tsx
+++ b/frontend/src/pages/contracts/ClausesStep.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import { fetchClauses } from "../../services/clauses";
+
+type Props = {
+  region: string;
+  value: Record<string, any>; // { [clauseId]: params }
+  onChange: (next: Record<string, any>) => void;
+};
+
+export default function ClausesStep({ region, value = {}, onChange }: Props) {
+  const [items, setItems] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetchClauses(region).then((d) => setItems(d.items));
+  }, [region]);
+
+  const toggle = (id: string) => {
+    const next = { ...value };
+    if (next[id]) delete next[id]; else next[id] = {};
+    onChange(next);
+  };
+
+  const setParam = (id: string, key: string, v: any) => {
+    onChange({ ...value, [id]: { ...(value[id] || {}), [key]: v } });
+  };
+
+  const Field = ({ cid, name, meta }: any) => {
+    if (meta.type === "number") {
+      return (
+        <input
+          type="number"
+          min={meta.min ?? undefined}
+          max={meta.max ?? undefined}
+          defaultValue={meta.default ?? undefined}
+          onChange={(e) => setParam(cid, name, Number(e.target.value))}
+        />
+      );
+    }
+    if (meta.type === "boolean") {
+      return (
+        <input
+          type="checkbox"
+          defaultChecked={!!meta.default}
+          onChange={(e) => setParam(cid, name, e.target.checked)}
+        />
+      );
+    }
+    // fallback string
+    return (
+      <input
+        type="text"
+        defaultValue={meta.default ?? ""}
+        onChange={(e) => setParam(cid, name, e.target.value)}
+      />
+    );
+  };
+
+  return (
+    <div>
+      {items.map((c) => {
+        const checked = !!value[c.id];
+        const meta = c.paramsMeta;
+        return (
+          <div key={c.id} style={{ border: "1px solid #eee", padding: 12, marginBottom: 10 }}>
+            <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input type="checkbox" checked={checked} onChange={() => toggle(c.id)} />
+              <strong>{c.label}</strong>
+            </label>
+
+            {checked && meta?.type === "object" && (
+              <div style={{ marginTop: 8, display: "grid", gap: 8 }}>
+                {Object.entries(meta.fields).map(([k, m]: any) => (
+                  <label key={k} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                    <small>{k}</small>
+                    <Field cid={c.id} name={k} meta={m} />
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/services/clauses.ts
+++ b/frontend/src/services/clauses.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export async function fetchClauses(region: string, version = "1.0.0") {
+  const { data } = await axios.get("/api/clauses", { params: { region, version } });
+  return data; // { version, region, items: [{id,label,version,paramsMeta}] }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,7 +31,7 @@ import demoContractRoutes from './routes/demoContract.routes';
 import { errorHandler } from './middleware/errorHandler';
 import appointmentsFlowRoutes from './routes/appointments.routes';
 import uploadRoutes from './routes/upload.routes';
-import clauseRoutes from './routes/clauses.routes';
+import clausesRoutes from './routes/clauses.routes';
 
 import helmet from 'helmet';
 
@@ -69,7 +69,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/verification', verificationRoutes);
 app.use('/api/kyc', identityRoutes);
 app.use('/api/properties', propertyRoutes);
-app.use('/api/clauses', clauseRoutes);
+app.use('/api', clausesRoutes);
 app.use('/api', uploadRoutes);
 app.use('/api', demoContractRoutes);
 app.use('/api', requireVerified, appointmentsFlowRoutes);

--- a/src/policies/clauses/index.ts
+++ b/src/policies/clauses/index.ts
@@ -1,27 +1,61 @@
-import { CLAUSES_BASE, CLAUSES_BY_REGION, type ClauseDefinition, type RegionKey } from "./catalog.v1";
+import { ZodTypeAny } from "zod";
+import { CLAUSES_BASE, CLAUSES_BY_REGION, CLAUSE_POLICY_VERSION } from "./catalog.v1";
 
-export type ClauseCatalogByRegion = Record<string, ClauseDefinition>;
+type ClauseDef = {
+  id: string;
+  version: string;
+  label: string;
+  paramsSchema: ZodTypeAny;
+  render: (params: any) => string;
+};
+type Catalog = Record<string, ClauseDef>;
 
-function normalizeRegion(region: string): string {
-  return region.trim().toLowerCase();
+/** Une base + cláusulas autonómicas según region */
+export function getCatalogByRegion(region?: string): Catalog {
+  const base: Catalog = CLAUSES_BASE as any;
+  const r = (region || "").toLowerCase();
+  if (r && !(CLAUSES_BY_REGION as any)[r]) {
+    return {} as Catalog;
+  }
+  const regional: Catalog = (r && (CLAUSES_BY_REGION as any)[r]) || {};
+  return { ...base, ...regional };
 }
 
-export function getCatalogByRegion(region: string): ClauseCatalogByRegion | null {
-  if (!region || typeof region !== "string") {
-    return null;
-  }
-  const normalized = normalizeRegion(region);
-  const regionalCatalog =
-    normalized === "general"
-      ? {}
-      : CLAUSES_BY_REGION[normalized as RegionKey] ?? null;
+/** Serializa un schema Zod a metadatos simples para formularios del front */
+export function zodToMeta(schema: ZodTypeAny): any {
+  const def: any = (schema as any)?._def;
 
-  if (normalized !== "general" && regionalCatalog === null) {
-    return null;
+  // Objetos
+  if (def?.typeName === "ZodObject") {
+    const shape = (schema as any).shape;
+    const fields: Record<string, any> = {};
+    for (const k of Object.keys(shape)) fields[k] = zodToMeta(shape[k]);
+    return { type: "object", fields };
   }
 
-  return {
-    ...CLAUSES_BASE,
-    ...(regionalCatalog ?? {}),
-  };
+  // Defaults / Effects (unwrap)
+  if (def?.typeName === "ZodDefault") {
+    const inner = zodToMeta(def.innerType);
+    inner.default = def.defaultValue();
+    return inner;
+  }
+  if (def?.typeName === "ZodEffects") {
+    return zodToMeta(def.schema);
+  }
+
+  // Primitivos
+  if (def?.typeName === "ZodNumber") {
+    return {
+      type: "number",
+      int: !!def.checks?.find((c: any) => c.kind === "int"),
+      min: def.checks?.find((c: any) => c.kind === "min")?.value,
+      max: def.checks?.find((c: any) => c.kind === "max")?.value,
+    };
+  }
+  if (def?.typeName === "ZodBoolean") return { type: "boolean" };
+  if (def?.typeName === "ZodString") return { type: "string" };
+
+  return { type: "unknown" };
 }
+
+export { CLAUSE_POLICY_VERSION };

--- a/src/routes/clauses.routes.ts
+++ b/src/routes/clauses.routes.ts
@@ -1,8 +1,46 @@
-import { Router } from "express";
-import { listClauses } from "../controllers/clauses.controller";
+import { Router, Request, Response } from "express";
+import { getCatalogByRegion, zodToMeta, CLAUSE_POLICY_VERSION } from "../policies/clauses";
 
-const router = Router();
+const r = Router();
 
-router.get("/", listClauses);
+/**
+ * GET /api/clauses?region=galicia&version=1.0.0
+ * Respuesta:
+ * {
+ *   version: "1.0.0",
+ *   region: "galicia",
+ *   items: [{ id, label, version, paramsMeta }]
+ * }
+ */
+r.get("/clauses", (req: Request, res: Response) => {
+  const region = String(req.query.region || "").toLowerCase() || undefined;
+  const requestedVersion = String(req.query.version || "") || CLAUSE_POLICY_VERSION;
 
-export default router;
+  // Por ahora solo la versión activa
+  if (requestedVersion !== CLAUSE_POLICY_VERSION) {
+    return res.status(400).json({
+      error: "unsupported_catalog_version",
+      supported: CLAUSE_POLICY_VERSION,
+    });
+  }
+
+  const catalog = getCatalogByRegion(region);
+  if (!catalog || Object.keys(catalog).length === 0) {
+    return res.status(400).json({ error: "region_not_supported" });
+  }
+
+  const items = Object.values(catalog).map((c) => ({
+    id: c.id,
+    label: c.label,
+    version: c.version,
+    paramsMeta: zodToMeta(c.paramsSchema),
+  }));
+
+  res.json({
+    version: CLAUSE_POLICY_VERSION,
+    region: region || null,
+    items,
+  });
+});
+
+export default r;

--- a/tests/clauses/clauses.routes.test.ts
+++ b/tests/clauses/clauses.routes.test.ts
@@ -1,0 +1,25 @@
+import request from "supertest";
+import { app } from "../../src/app";
+
+describe("GET /api/clauses", () => {
+  it("devuelve catálogo base+Galicia con paramsMeta", async () => {
+    const res = await request(app).get("/api/clauses?region=galicia&version=1.0.0").expect(200);
+    expect(res.body.version).toBe("1.0.0");
+    expect(res.body.region).toBe("galicia");
+    expect(Array.isArray(res.body.items)).toBe(true);
+    const igvs = res.body.items.find((i: any) => i.id === "fianza_autonomica");
+    expect(igvs).toBeTruthy();
+    // paramsMeta debe existir aunque sea objeto vacío (por nuestra serialización)
+    expect(igvs.paramsMeta).toBeDefined();
+  });
+
+  it("falla si version no es soportada", async () => {
+    const res = await request(app).get("/api/clauses?region=madrid&version=0.9.0").expect(400);
+    expect(res.body.error).toBe("unsupported_catalog_version");
+  });
+
+  it("falla si region inválida", async () => {
+    const res = await request(app).get("/api/clauses?region=venus").expect(400);
+    expect(res.body.error).toBe("region_not_supported");
+  });
+});


### PR DESCRIPTION
## Summary
- add catalog utilities to merge clauses by region and expose Zod metadata
- expose GET /api/clauses endpoint returning serialized catalog with params metadata
- add Jest coverage plus frontend service and ClausesStep wizard sketch using the catalog

## Testing
- npm test -- tests/clauses/clauses.routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9bc42d188832aa2096967497b176c