### PR TITLE
Implement contract lifecycle transitions and tests

### DIFF
--- a/src/controllers/contract.lifecycle.controller.ts
+++ b/src/controllers/contract.lifecycle.controller.ts
@@ -1,0 +1,40 @@
+import { Request, Response } from "express";
+import { Contract } from "../models/contract.model";
+import { transitionContract } from "../services/contractState";
+import { recordContractHistory } from "../utils/history";
+
+export async function activate(req: Request, res: Response) {
+  const { id } = req.params;
+
+  try {
+    const c = await Contract.findById(id);
+    if (!c) {
+      return res.status(404).json({ error: "contract_not_found" });
+    }
+
+    if (c.status !== "signed") {
+      return res.status(409).json({ error: "must_be_signed" });
+    }
+
+    const now = new Date();
+    if (c.startDate && now < c.startDate) {
+      return res.status(409).json({ error: "start_date_not_reached" });
+    }
+
+    const updated = await transitionContract(id, "active");
+
+    await recordContractHistory(id, "ACTIVATED", (req as any).user?.id, {
+      startDate: c.startDate,
+    });
+
+    return res.json({ ok: true, status: updated.status });
+  } catch (error: any) {
+    const status = error?.status ?? 500;
+    const payload: Record<string, unknown> = {
+      error: error?.message || "activation_failed",
+    };
+    if (error?.from) payload.from = error.from;
+    if (error?.to) payload.to = error.to;
+    return res.status(status).json(payload);
+  }
+}

--- a/src/controllers/contract.signature.controller.ts
+++ b/src/controllers/contract.signature.controller.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from "express";
+import { transitionContract } from "../services/contractState";
+import { recordContractHistory } from "../utils/history";
+
+export async function signatureCallback(req: Request, res: Response) {
+  const { id } = req.params;
+
+  try {
+    const contract = await transitionContract(id, "signed");
+
+    await recordContractHistory(id, "SIGNED", (req as any).user?.id, {
+      provider: "mock",
+      note: "signature completed (mock)",
+    });
+
+    return res.json({ ok: true, status: contract.status });
+  } catch (error: any) {
+    const status = error?.status ?? 500;
+    const payload: Record<string, unknown> = {
+      error: error?.message || "signature_callback_failed",
+    };
+    if (error?.from) payload.from = error.from;
+    if (error?.to) payload.to = error.to;
+    return res.status(status).json(payload);
+  }
+}

--- a/src/controllers/contract.terminate.controller.ts
+++ b/src/controllers/contract.terminate.controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from "express";
+import { transitionContract } from "../services/contractState";
+import { recordContractHistory } from "../utils/history";
+
+export async function terminate(req: Request, res: Response) {
+  const { id } = req.params;
+  const { reason } = req.body || {};
+
+  try {
+    const c = await transitionContract(id, "terminated");
+    await recordContractHistory(id, "TERMINATED", (req as any).user?.id, { reason });
+    return res.json({ ok: true, status: c.status });
+  } catch (error: any) {
+    const status = error?.status ?? 500;
+    const payload: Record<string, unknown> = {
+      error: error?.message || "termination_failed",
+    };
+    if (error?.from) payload.from = error.from;
+    if (error?.to) payload.to = error.to;
+    return res.status(status).json(payload);
+  }
+}

--- a/src/models/contract.model.ts
+++ b/src/models/contract.model.ts
@@ -41,7 +41,8 @@ export interface IContract extends Document {
    * upon creation. Once both parties have signed, the status transitions
    * to 'active'. When the rental period ends or the landlord marks it as
    * finished, the status should be set to 'completed'. In the event of
-   * early termination, the status can be set to 'cancelled'.
+   * early termination, the status can be set to 'terminated'. Legacy
+   * workflows may still use 'cancelled' for similar scenarios.
    */
   status:
     | 'draft'
@@ -51,7 +52,8 @@ export interface IContract extends Document {
     | 'active'
     | 'completed'
     | 'cancelled'
-    | 'pending_signature';
+    | 'pending_signature'
+    | 'terminated';
   /**
    * Indicates whether the deposit (fianza) has been paid. Deposits can be
    * transferred either to a platform escrow account or to a public authority
@@ -117,7 +119,17 @@ const contractSchema = new Schema<IContract>(
     // Current lifecycle status of the contract
     status: {
       type: String,
-      enum: ['draft', 'generated', 'signing', 'signed', 'active', 'completed', 'cancelled', 'pending_signature'],
+      enum: [
+        'draft',
+        'generated',
+        'signing',
+        'signed',
+        'active',
+        'completed',
+        'cancelled',
+        'pending_signature',
+        'terminated',
+      ],
       default: 'draft',
     },
     // Deposit paid flag and timestamp

--- a/src/routes/contract.routes.ts
+++ b/src/routes/contract.routes.ts
@@ -1,5 +1,8 @@
 import { Router } from 'express';
 import * as contractController from '../controllers/contract.controller';
+import * as lifeCtrl from '../controllers/contract.lifecycle.controller';
+import * as signCtrl from '../controllers/contract.signature.controller';
+import * as termCtrl from '../controllers/contract.terminate.controller';
 import { authenticate } from '../middleware/auth.middleware';
 
 const router = Router();
@@ -25,11 +28,20 @@ router.post('/:id/pay', authenticate, contractController.initiatePayment);
 // Iniciar firma electrónica de contrato
 router.post('/:id/signature', authenticate, contractController.requestSignature);
 
+// Callback de firma (mock)
+router.post('/:id/signature/callback', signCtrl.signatureCallback);
+
+// Activar contrato
+router.post('/:id/activate', authenticate, lifeCtrl.activate);
+
 // Enviar recordatorio de pago de renta
 router.post('/:id/remind', authenticate, contractController.sendRentReminder);
 
 // Enviar notificación de renovación
 router.post('/:id/renew', authenticate, contractController.sendRenewalNotification);
+
+// Terminar contrato
+router.post('/:id/terminate', authenticate, termCtrl.terminate);
 
 // Pagar fianza
 router.post('/:id/deposit', authenticate, contractController.payDeposit);

--- a/src/services/contractState.ts
+++ b/src/services/contractState.ts
@@ -1,0 +1,26 @@
+import { Contract } from "../models/contract.model";
+
+export type ContractState = "draft" | "pending_signature" | "signed" | "active" | "terminated";
+
+const ALLOWED: Record<ContractState, ContractState[]> = {
+  draft: ["pending_signature", "terminated"],
+  pending_signature: ["signed", "terminated"],
+  signed: ["active", "terminated"],
+  active: ["terminated"],
+  terminated: [],
+};
+
+export function canTransition(from: ContractState, to: ContractState) {
+  return ALLOWED[from]?.includes(to) ?? false;
+}
+
+export async function transitionContract(id: string, to: ContractState) {
+  const c = await Contract.findById(id);
+  if (!c) throw Object.assign(new Error("contract_not_found"), { status: 404 });
+  if (!canTransition((c.status as ContractState) ?? "draft", to)) {
+    throw Object.assign(new Error("invalid_transition"), { status: 409, from: c.status, to });
+  }
+  c.status = to;
+  await c.save();
+  return c;
+}

--- a/tests/contracts/lifecycle.test.ts
+++ b/tests/contracts/lifecycle.test.ts
@@ -1,0 +1,47 @@
+import request from "supertest";
+import { app } from "../../src/app";
+import { connectDb, disconnectDb, clearDb } from "../utils/db";
+
+describe("Contract lifecycle", () => {
+  let id: string;
+
+  beforeAll(connectDb);
+  afterAll(disconnectDb);
+  afterEach(clearDb);
+
+  beforeEach(async () => {
+    const res = await request(app).post("/api/contracts").send({
+      landlord: "507f1f77bcf86cd799439011",
+      tenant: "507f1f77bcf86cd799439012",
+      property: "507f1f77bcf86cd799439013",
+      region: "galicia",
+      rent: 750,
+      deposit: 750,
+      startDate: new Date(Date.now() - 86400000).toISOString(),
+      endDate: "2026-09-30",
+      clauses: [{ id: "duracion_prorroga", params: { mesesIniciales: 12, mesesProrroga: 12 } }],
+    });
+    id = res.body.contract._id;
+  });
+
+  it("pasa a signed con el callback mock", async () => {
+    const res = await request(app).post(`/api/contracts/${id}/signature/callback`).send().expect(200);
+    expect(res.body.status).toBe("signed");
+  });
+
+  it("activa si la fecha de inicio ya llegó", async () => {
+    await request(app).post(`/api/contracts/${id}/signature/callback`).send().expect(200);
+    const res = await request(app).post(`/api/contracts/${id}/activate`).send().expect(200);
+    expect(res.body.status).toBe("active");
+  });
+
+  it("termina el contrato", async () => {
+    await request(app).post(`/api/contracts/${id}/signature/callback`).send().expect(200);
+    await request(app).post(`/api/contracts/${id}/activate`).send().expect(200);
+    const res = await request(app)
+      .post(`/api/contracts/${id}/terminate`)
+      .send({ reason: "mutuo_acuerdo" })
+      .expect(200);
+    expect(res.body.status).toBe("terminated");
+  });
+});


### PR DESCRIPTION
## Summary
- add a contract state transition helper and expose lifecycle endpoints for signature callbacks, manual activation, and termination
- persist lifecycle changes in the contract model and history while extending the schema with the terminated status
- cover the new flow with contract lifecycle integration tests

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c9be99878c832abd828009983bd290