### PR TITLE
Enforce verified owner requirement on property publishing

### DIFF
--- a/src/controllers/property.controller.ts
+++ b/src/controllers/property.controller.ts
@@ -31,6 +31,13 @@ export async function publish(req: Request, res: Response) {
   const { id } = req.params;
   const p = await Property.findById(id);
   if (!p) return res.status(404).json({ error: 'not_found' });
+  const user: any = (req as any).user;
+  const userId = user?._id ?? user?.id;
+  const isOwner = userId ? String(userId) === String(p.owner) : false;
+  const isAdmin = user?.role === 'admin';
+  if (!isAdmin && (!isOwner || !user?.isVerified)) {
+    return res.status(403).json({ error: 'owner_not_verified' });
+  }
   if ((p.images?.length || 0) < 3) return res.status(400).json({ error: 'min_images_3' });
   p.status = 'active';
   await p.save();

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -12,9 +12,19 @@ export const authenticate = (req: Request, res: Response, next: NextFunction) =>
   const token = req.headers.authorization?.split(' ')[1];
   if (!token) {
     if (process.env.NODE_ENV === 'test') {
+      const idHeader = (req.headers['x-user-id'] as string) || '000000000000000000000001';
+      const roleHeader = (req.headers['x-user-role'] as string) || 'landlord';
+      const verifiedHeader = req.headers['x-user-verified'];
+      const isVerified =
+        verifiedHeader !== undefined
+          ? ['true', '1', 'yes'].includes(String(verifiedHeader).toLowerCase())
+          : true;
+
       const fallbackUser = {
-        id: (req.headers['x-user-id'] as string) || '000000000000000000000001',
-        role: (req.headers['x-user-role'] as string) || 'landlord',
+        id: idHeader,
+        _id: idHeader,
+        role: roleHeader,
+        isVerified,
       };
       (req as any).user = fallbackUser;
       return next();
@@ -23,7 +33,17 @@ export const authenticate = (req: Request, res: Response, next: NextFunction) =>
   }
   try {
     const decoded = jwt.verify(token, JWT_SECRET) as any;
-    (req as any).user = decoded;
+    const resolvedId = decoded._id || decoded.id;
+    (req as any).user = {
+      ...decoded,
+      id: resolvedId,
+      _id: resolvedId,
+      isVerified:
+        decoded.isVerified ??
+        decoded.verified ??
+        decoded.is_verified ??
+        (decoded.status ? decoded.status === 'verified' : false),
+    };
     next();
   } catch {
     res.status(401).json({ error: 'Token inválido' });

--- a/src/middleware/requireVerified.ts
+++ b/src/middleware/requireVerified.ts
@@ -11,6 +11,13 @@ export const requireVerified = async (
   res: Response,
   next: NextFunction,
 ) => {
+  const user: any = (req as any).user;
+  if (user) {
+    if (user.role === 'admin') return next();
+    if (user.isVerified) return next();
+    return res.status(403).json({ error: 'owner_not_verified' });
+  }
+
   // Dev bypass: allow skipping verification when explicitly enabled and not in production
   if (process.env.ALLOW_UNVERIFIED === 'true' && process.env.NODE_ENV !== 'production') {
     return next();

--- a/src/routes/property.routes.ts
+++ b/src/routes/property.routes.ts
@@ -5,6 +5,7 @@ import { validate } from '../middleware/validate';
 import * as ctrl from '../controllers/property.controller';
 import { propertyCreateSchema, propertyUpdateSchema } from '../validators/property.schema';
 import { asyncHandler } from '../utils/asyncHandler';
+import { requireVerified } from '../middleware/requireVerified';
 
 const r = Router();
 
@@ -22,7 +23,13 @@ r.put(
   validate(propertyUpdateSchema),
   asyncHandler(ctrl.update),
 );
-r.post('/properties/:id/publish', authenticate, authorizeRoles('landlord', 'admin'), asyncHandler(ctrl.publish));
+r.post(
+  '/properties/:id/publish',
+  authenticate,
+  authorizeRoles('landlord', 'admin'),
+  requireVerified,
+  asyncHandler(ctrl.publish),
+);
 r.post('/properties/:id/archive', authenticate, authorizeRoles('landlord', 'admin'), asyncHandler(ctrl.archive));
 
 r.get('/properties/:id', asyncHandler(ctrl.getById));

--- a/tests/properties/property.routes.test.ts
+++ b/tests/properties/property.routes.test.ts
@@ -3,6 +3,7 @@ import { app } from "../../src/app";
 import { connectDb, disconnectDb, clearDb } from "../utils/db";
 
 describe("Properties (minimal)", () => {
+  const ownerId = "507f1f77bcf86cd799439011";
   let pid: string;
 
   beforeAll(connectDb);
@@ -14,7 +15,7 @@ describe("Properties (minimal)", () => {
 
   it("create draft", async () => {
     const payload = {
-      owner: "507f1f77bcf86cd799439011",
+      owner: ownerId,
       title: "Piso céntrico",
       address: "C/ Mayor 1",
       region: "galicia",
@@ -30,14 +31,62 @@ describe("Properties (minimal)", () => {
       availableFrom: "2025-10-01",
       images: ["https://cdn/x1.jpg", "https://cdn/x2.jpg", "https://cdn/x3.jpg"],
     };
-    const res = await request(app).post("/api/properties").send(payload).expect(201);
+    const res = await request(app)
+      .post("/api/properties")
+      .set("x-user-id", ownerId)
+      .set("x-user-role", "landlord")
+      .set("x-user-verified", "true")
+      .send(payload)
+      .expect(201);
     pid = res.body._id;
     expect(res.body.status).toBe("draft");
   });
 
   it("publish -> active", async () => {
-    const res = await request(app).post(`/api/properties/${pid}/publish`).send().expect(200);
+    const res = await request(app)
+      .post(`/api/properties/${pid}/publish`)
+      .set("x-user-id", ownerId)
+      .set("x-user-role", "landlord")
+      .set("x-user-verified", "true")
+      .send()
+      .expect(200);
     expect(res.body.status).toBe("active");
+  });
+
+  it("publish bloqueado si no verificado", async () => {
+    const payload = {
+      owner: ownerId,
+      title: "Piso sin verificar",
+      address: "C/ Secundaria 2",
+      region: "galicia",
+      city: "A Coruña",
+      location: { lng: -8.409, lat: 43.362 },
+      price: 750,
+      deposit: 750,
+      sizeM2: 60,
+      rooms: 2,
+      bathrooms: 1,
+      furnished: true,
+      petsAllowed: false,
+      availableFrom: "2025-11-01",
+      images: ["https://cdn/y1.jpg", "https://cdn/y2.jpg", "https://cdn/y3.jpg"],
+    };
+    const created = await request(app)
+      .post("/api/properties")
+      .set("x-user-id", ownerId)
+      .set("x-user-role", "landlord")
+      .set("x-user-verified", "true")
+      .send(payload)
+      .expect(201);
+
+    const res = await request(app)
+      .post(`/api/properties/${created.body._id}/publish`)
+      .set("x-user-id", ownerId)
+      .set("x-user-role", "landlord")
+      .set("x-user-verified", "false")
+      .send()
+      .expect(403);
+    expect(res.body.error).toBe("owner_not_verified");
   });
 
   it("search by price & geo", async () => {


### PR DESCRIPTION
## Summary
- ensure authentication middleware populates `_id` and `isVerified` flags for the current user
- allow `requireVerified` to honor authenticated users and apply it to the property publish route
- gate property publishing on verified owners and cover the new rules with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9d2311cb8832a920f7d35ba50c7e6