### PR TITLE
Add property alert notifications with mock email

### DIFF
--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,32 +1,37 @@
-import nodemailer from 'nodemailer';
-
-// Configure the transport using environment variables. When deploying you
-// should set SMTP_HOST, SMTP_PORT, SMTP_USER and SMTP_PASS in your .env file.
-const transporter = nodemailer.createTransport({
-  host: process.env.SMTP_HOST,
-  port: Number(process.env.SMTP_PORT) || 587,
-  secure: false,
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS,
-  },
-});
-
 /**
- * Send an email notification when a new contract has been created. This is a
- * placeholder; in a production environment you would customise the
- * message and handle errors appropriately.
+ * Email utility functions used across the application. Right now this module
+ * exposes a very simple console-based mock that simulates email delivery. When
+ * a real provider (Sendgrid, SES, etc.) is integrated the implementation of
+ * sendEmail can be replaced while keeping the rest of the app untouched.
  */
-export const sendContractCreatedEmail = async (to: string, contractId: string) => {
-  const mailOptions = {
-    from: process.env.SMTP_FROM || 'noreply@rental-app.com',
+export async function sendEmail(userId: string, subject: string, body: string) {
+  console.log(`[EMAIL MOCK] To user=${userId} | ${subject}\n${body}`);
+}
+
+export async function sendPriceAlert(userId: string, property: any) {
+  return sendEmail(
+    userId,
+    'Aviso: cambio de precio en propiedad',
+    `La propiedad "${property.title}" ahora cuesta ${property.price} €`,
+  );
+}
+
+export async function sendAvailabilityAlert(userId: string, property: any) {
+  const range = property.availableTo
+    ? `${property.availableFrom} - ${property.availableTo}`
+    : property.availableFrom;
+
+  return sendEmail(
+    userId,
+    'Aviso: cambio de disponibilidad',
+    `La propiedad "${property.title}" tiene nueva fecha de disponibilidad: ${range}`,
+  );
+}
+
+export async function sendContractCreatedEmail(to: string, contractId: string) {
+  return sendEmail(
     to,
-    subject: 'Nuevo contrato creado',
-    text: `Se ha creado un nuevo contrato con ID ${contractId}.`,
-  };
-  try {
-    await transporter.sendMail(mailOptions);
-  } catch (error) {
-    console.error('Error enviando email de notificación:', error);
-  }
-};
+    'Nuevo contrato creado',
+    `Se ha creado un nuevo contrato con ID ${contractId}.`,
+  );
+}

--- a/tests/properties/property.alerts.test.ts
+++ b/tests/properties/property.alerts.test.ts
@@ -1,0 +1,81 @@
+import request from "supertest";
+import { app } from "../../src/app";
+import { AlertSubscription } from "../../src/models/alertSubscription.model";
+import { connectDb, disconnectDb, clearDb } from "../utils/db";
+
+describe("Property alerts", () => {
+  let pid: string;
+  let logSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    await connectDb();
+    const res = await request(app).post("/api/properties").send({
+      owner: "507f1f77bcf86cd799439011",
+      title: "Piso alertas test",
+      address: "C/ Falsa 123",
+      region: "galicia",
+      city: "A Coruña",
+      location: { lng: -8.4, lat: 43.36 },
+      price: 700,
+      deposit: 700,
+      sizeM2: 60,
+      rooms: 2,
+      bathrooms: 1,
+      furnished: false,
+      petsAllowed: true,
+      availableFrom: "2025-11-01",
+      images: ["https://cdn/x1.jpg", "https://cdn/x2.jpg", "https://cdn/x3.jpg"],
+    });
+    pid = res.body._id;
+    await AlertSubscription.create({
+      userId: "507f1f77bcf86cd799439099",
+      propertyId: pid,
+      type: "price",
+    });
+    await AlertSubscription.create({
+      userId: "507f1f77bcf86cd799439098",
+      propertyId: pid,
+      type: "availability",
+    });
+  });
+
+  afterAll(async () => {
+    await clearDb();
+    await disconnectDb();
+  });
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("triggers price alert on update", async () => {
+    await request(app).put(`/api/properties/${pid}`).send({ price: 650 }).expect(200);
+
+    const priceAlertLogged = logSpy.mock.calls.some(([msg]) =>
+      typeof msg === "string" &&
+      msg.includes("Aviso: cambio de precio en propiedad") &&
+      msg.includes("507f1f77bcf86cd799439099"),
+    );
+
+    expect(priceAlertLogged).toBe(true);
+  });
+
+  it("triggers availability alert on update", async () => {
+    await request(app)
+      .put(`/api/properties/${pid}`)
+      .send({ availableFrom: "2025-12-15", availableTo: "2026-01-10" })
+      .expect(200);
+
+    const availabilityAlertLogged = logSpy.mock.calls.some(([msg]) =>
+      typeof msg === "string" &&
+      msg.includes("Aviso: cambio de disponibilidad") &&
+      msg.includes("507f1f77bcf86cd799439098"),
+    );
+
+    expect(availabilityAlertLogged).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the email utility with a console-based mock helper for alerts
- trigger price and availability alert emails when properties change
- add tests validating the mocked notifications for price and availability updates

## Testing
- npm test -- property.alerts

------
https://chatgpt.com/codex/tasks/task_e_68c9d278138c832a97d2662e0e23f252