### PR TITLE
feat: add frontend contract wizard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import ProList from './pages/ProList';
 import ProDetail from './pages/ProDetail';
 import Placeholder from './pages/common/Placeholder';
 import AutoPlaceholder from './pages/common/AutoPlaceholder';
+import ContractWizard from './pages/contracts/ContractWizard';
 
 const ProtectedRoute: React.FC<{ children: React.ReactElement; roles?: Array<'tenant'|'landlord'|'admin'|'pro'> }> = ({ children, roles }) => {
   const { token, user } = useAuth();
@@ -40,6 +41,7 @@ const App: React.FC = () => {
         <Route path="/dashboard" element={<ProtectedRoute>{dashboard}</ProtectedRoute>} />
         <Route path="/landlord/properties" element={<ProtectedRoute roles={['landlord','admin']}><LandlordDashboard /></ProtectedRoute>} />
         <Route path="/contracts" element={<ProtectedRoute><MyContracts /></ProtectedRoute>} />
+        <Route path="/contracts/new" element={<ProtectedRoute><ContractWizard /></ProtectedRoute>} />
         <Route path="/contracts/:id" element={<ProtectedRoute><ContractDetail /></ProtectedRoute>} />
         <Route path="/earnings" element={<ProtectedRoute roles={['landlord','admin']}><Earnings /></ProtectedRoute>} />
         <Route path="/pro" element={<ProtectedRoute roles={['pro','admin']}><ProDashboard /></ProtectedRoute>} />

--- a/frontend/src/pages/contracts/ContractWizard.tsx
+++ b/frontend/src/pages/contracts/ContractWizard.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import WizardStep1Basics from './WizardStep1Basics';
+import WizardStep2Clauses from './WizardStep2Clauses';
+import WizardStep3Review from './WizardStep3Review';
+
+export default function ContractWizard() {
+  const [step, setStep] = useState(1);
+  const [basics, setBasics] = useState<any>({});
+  const [clauses, setClauses] = useState<Record<string, any>>({});
+  const [created, setCreated] = useState<any>(null);
+
+  if (created) {
+    return (
+      <div style={{ maxWidth: 760 }}>
+        <h2>Contrato creado ✅</h2>
+        <p>
+          Estado: <b>{created.status}</b>
+        </p>
+        <p>
+          PDF hash: <code>{created.pdfHash}</code>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '24px' }}>
+      {step === 1 && <WizardStep1Basics value={basics} onChange={setBasics} onNext={() => setStep(2)} />}
+      {step === 2 && (
+        <WizardStep2Clauses
+          region={basics.region}
+          value={clauses}
+          onChange={setClauses}
+          onNext={() => setStep(3)}
+          onBack={() => setStep(1)}
+        />
+      )}
+      {step === 3 && <WizardStep3Review basics={basics} clauses={clauses} onBack={() => setStep(2)} onCreated={setCreated} />}
+    </div>
+  );
+}

--- a/frontend/src/pages/contracts/WizardStep1Basics.tsx
+++ b/frontend/src/pages/contracts/WizardStep1Basics.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+type Props = { value: any; onChange: (v: any) => void; onNext: () => void };
+export default function WizardStep1Basics({ value, onChange, onNext }: Props) {
+  const set = (k: string, v: any) => onChange({ ...value, [k]: v });
+  return (
+    <div style={{ display: 'grid', gap: 12, maxWidth: 560 }}>
+      <h2>Datos del contrato</h2>
+      <input placeholder="ID Arrendador" value={value.landlord || ''} onChange={(e) => set('landlord', e.target.value)} />
+      <input placeholder="ID Inquilino" value={value.tenant || ''} onChange={(e) => set('tenant', e.target.value)} />
+      <input placeholder="ID Propiedad" value={value.property || ''} onChange={(e) => set('property', e.target.value)} />
+      <select value={value.region || ''} onChange={(e) => set('region', e.target.value)}>
+        <option value="">Selecciona CCAA</option>
+        <option value="galicia">Galicia</option>
+        <option value="catalunya">Cataluña</option>
+        <option value="madrid">Madrid</option>
+      </select>
+      <input type="number" placeholder="Renta €/mes" value={value.rent || ''} onChange={(e) => set('rent', Number(e.target.value))} />
+      <input type="number" placeholder="Fianza €" value={value.deposit || ''} onChange={(e) => set('deposit', Number(e.target.value))} />
+      <label>
+        Inicio <input type="date" value={value.startDate || ''} onChange={(e) => set('startDate', e.target.value)} />
+      </label>
+      <label>
+        Fin <input type="date" value={value.endDate || ''} onChange={(e) => set('endDate', e.target.value)} />
+      </label>
+      <button
+        disabled={
+          !value.landlord ||
+          !value.tenant ||
+          !value.property ||
+          !value.region ||
+          !value.rent ||
+          !value.deposit ||
+          !value.startDate ||
+          !value.endDate
+        }
+        onClick={onNext}
+      >
+        Siguiente
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/contracts/WizardStep2Clauses.tsx
+++ b/frontend/src/pages/contracts/WizardStep2Clauses.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { getClauses } from '../../services/contracts';
+
+type Props = { region: string; value: Record<string, any>; onChange: (v: any) => void; onNext: () => void; onBack: () => void };
+export default function WizardStep2Clauses({ region, value = {}, onChange, onNext, onBack }: Props) {
+  const [items, setItems] = useState<any[]>([]);
+  useEffect(() => {
+    if (region) getClauses(region).then((d) => setItems(d.items));
+  }, [region]);
+
+  const toggle = (id: string) => {
+    const next = { ...value };
+    if (next[id]) delete next[id];
+    else next[id] = {};
+    onChange(next);
+  };
+  const setParam = (id: string, key: string, v: any) => onChange({ ...value, [id]: { ...(value[id] || {}), [key]: v } });
+
+  const Field = ({ cid, name, meta }: any) => {
+    if (meta.type === 'number')
+      return (
+        <input
+          type="number"
+          min={meta.min ?? undefined}
+          max={meta.max ?? undefined}
+          defaultValue={meta.default ?? undefined}
+          onChange={(e) => setParam(cid, name, Number(e.target.value))}
+        />
+      );
+    if (meta.type === 'boolean')
+      return <input type="checkbox" defaultChecked={!!meta.default} onChange={(e) => setParam(cid, name, e.target.checked)} />;
+    return <input type="text" defaultValue={meta.default ?? ''} onChange={(e) => setParam(cid, name, e.target.value)} />;
+  };
+
+  return (
+    <div style={{ display: 'grid', gap: 12, maxWidth: 760 }}>
+      <h2>Cláusulas del contrato ({region})</h2>
+      {items.map((c) => {
+        const checked = !!value[c.id];
+        return (
+          <div key={c.id} style={{ border: '1px solid #eee', borderRadius: 8, padding: 12 }}>
+            <label style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <input type="checkbox" checked={checked} onChange={() => toggle(c.id)} />
+              <strong>{c.label}</strong>
+            </label>
+            {checked && c.paramsMeta?.type === 'object' && (
+              <div style={{ marginTop: 8, display: 'grid', gap: 8 }}>
+                {Object.entries(c.paramsMeta.fields).map(([k, m]: any) => (
+                  <label key={k} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    <small>{k}</small>
+                    <Field cid={c.id} name={k} meta={m} />
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={onBack}>Atrás</button>
+        <button onClick={onNext}>Siguiente</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/contracts/WizardStep3Review.tsx
+++ b/frontend/src/pages/contracts/WizardStep3Review.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { createContract } from '../../services/contracts';
+
+type Props = { basics: any; clauses: Record<string, any>; onBack: () => void; onCreated: (c: any) => void };
+export default function WizardStep3Review({ basics, clauses, onBack, onCreated }: Props) {
+  const handleCreate = async () => {
+    const payload = {
+      landlord: basics.landlord,
+      tenant: basics.tenant,
+      property: basics.property,
+      region: basics.region,
+      rent: basics.rent,
+      deposit: basics.deposit,
+      startDate: basics.startDate,
+      endDate: basics.endDate,
+      clauses: Object.entries(clauses).map(([id, params]) => ({ id, params })),
+    };
+    const contract = await createContract(payload);
+    onCreated(contract);
+  };
+
+  return (
+    <div style={{ display: 'grid', gap: 12, maxWidth: 760 }}>
+      <h2>Revisión</h2>
+      <pre style={{ background: '#fafafa', padding: 12, borderRadius: 6 }}>
+        {JSON.stringify({ ...basics, clauses }, null, 2)}
+      </pre>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={onBack}>Atrás</button>
+        <button onClick={handleCreate}>Crear contrato</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/contracts.ts
+++ b/frontend/src/services/contracts.ts
@@ -46,3 +46,13 @@ export const downloadPdf = async (token: string, id: string) => {
   });
   return res.data as Blob;
 };
+
+export async function getClauses(region: string, version = '1.0.0') {
+  const { data } = await axios.get(`${API_BASE}/api/clauses`, { params: { region, version } });
+  return data as { version: string; region: string; items: Array<{ id: string; label: string; version: string; paramsMeta: any }> };
+}
+
+export async function createContract(payload: any) {
+  const { data } = await axios.post(`${API_BASE}/api/contracts`, payload);
+  return data.contract as any;
+}


### PR DESCRIPTION
## Summary
- add contract creation wizard pages to guide through basics, clauses, and review
- expose clause catalog fetch and contract creation helpers in the contracts service
- register the protected /contracts/new route to launch the wizard

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ca754a7330832a8f228c87b22b4345