### PR TITLE
feat: add property list, detail, and favorites pages

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -18,7 +18,15 @@ jest.mock('react-router-dom', () => ({
 }), { virtual: true });
 
 // Mock other external dependencies
-jest.mock('axios', () => ({ default: { post: jest.fn(), get: jest.fn() } }), { virtual: true });
+jest.mock('axios', () => {
+  const axiosMock = {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  } as any;
+  axiosMock.create = jest.fn(() => axiosMock);
+  return { __esModule: true, default: axiosMock };
+}, { virtual: true });
 jest.mock('@stripe/stripe-js', () => ({ loadStripe: jest.fn(async () => null) }), { virtual: true });
 
 test('la app renderiza sin crashear', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,9 @@ import ProDetail from './pages/ProDetail';
 import Placeholder from './pages/common/Placeholder';
 import AutoPlaceholder from './pages/common/AutoPlaceholder';
 import ContractWizard from './pages/contracts/ContractWizard';
+import PropertiesList from './pages/properties/PropertiesList';
+import PropertyDetailPage from './pages/properties/PropertyDetail';
+import FavoritesPage from './pages/properties/FavoritesPage';
 
 const ProtectedRoute: React.FC<{ children: React.ReactElement; roles?: Array<'tenant'|'landlord'|'admin'|'pro'> }> = ({ children, roles }) => {
   const { token, user } = useAuth();
@@ -49,6 +52,9 @@ const App: React.FC = () => {
         <Route path="/pros/:id" element={<ProDetail />} />
         <Route path="/favorites" element={<ProtectedRoute roles={['tenant','landlord','admin']}><Favorites /></ProtectedRoute>} />
         <Route path="/verify" element={<ProtectedRoute><Verification /></ProtectedRoute>} />
+        <Route path="/properties" element={<PropertiesList />} />
+        <Route path="/properties/:id" element={<PropertyDetailPage />} />
+        <Route path="/me/favorites" element={<FavoritesPage />} />
         <Route path="/p/:id" element={<PropertyDetail />} />
         {/* Role catch-alls to evitar 404 mientras se completa cada sección */}
         <Route path="/tenant/*" element={<ProtectedRoute roles={['tenant']}><AutoPlaceholder /></ProtectedRoute>} />

--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import PropertiesList from './pages/properties/PropertiesList';
+import PropertyDetail from './pages/properties/PropertyDetail';
+import FavoritesPage from './pages/properties/FavoritesPage';
+
+export default function AppRoutes() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        {/* ...otras rutas */}
+        <Route path="/properties" element={<PropertiesList />} />
+        <Route path="/properties/:id" element={<PropertyDetail />} />
+        <Route path="/me/favorites" element={<FavoritesPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/components/PropertyCard.tsx
+++ b/frontend/src/components/PropertyCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+type Props = {
+  p: any;
+  onFavToggle?: (id: string, liked: boolean) => void;
+};
+
+export default function PropertyCard({ p, onFavToggle }: Props) {
+  const image = p.images?.[0] || 'https://via.placeholder.com/600x400?text=Property';
+  const liked = !!p._liked;
+
+  return (
+    <div style={{ border: '1px solid #eee', borderRadius: 10, overflow: 'hidden' }}>
+      <Link to={`/properties/${p._id}`} style={{ display: 'block' }}>
+        <img src={image} alt={p.title} style={{ width: '100%', height: 180, objectFit: 'cover' }} />
+      </Link>
+      <div style={{ padding: 12, display: 'grid', gap: 6 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <strong>{p.price} €</strong>
+          {onFavToggle && (
+            <button
+              onClick={() => onFavToggle(p._id, !liked)}
+              aria-label="fav"
+              style={{ background: 'none', border: 'none', cursor: 'pointer' }}
+            >
+              {liked ? '❤️' : '🤍'}
+            </button>
+          )}
+        </div>
+        <div style={{ color: '#444' }}>{p.title}</div>
+        <small style={{ color: '#777' }}>
+          {p.city} · {p.rooms} hab · {p.sizeM2 || '—'} m²
+        </small>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PropertyFilters.tsx
+++ b/frontend/src/components/PropertyFilters.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import type { SearchParams } from '../services/properties';
+
+type Props = {
+  initial?: Partial<SearchParams>;
+  onApply: (params: SearchParams) => void;
+};
+
+export default function PropertyFilters({ initial = {}, onApply }: Props) {
+  const [state, setState] = useState<SearchParams>({ sort: 'createdAt', dir: 'desc', limit: 12, ...initial });
+  const update = (key: keyof SearchParams, value: any) => {
+    setState(prev => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div style={{ display: 'grid', gap: 8, padding: 12, border: '1px solid #eee', borderRadius: 8 }}>
+      <div style={{ display: 'grid', gap: 6 }}>
+        <input
+          placeholder="Buscar…"
+          value={state.q || ''}
+          onChange={event => update('q', event.target.value)}
+        />
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          <input
+            placeholder="Región"
+            value={state.region || ''}
+            onChange={event => update('region', event.target.value)}
+          />
+          <input
+            placeholder="Ciudad"
+            value={state.city || ''}
+            onChange={event => update('city', event.target.value)}
+          />
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          <input
+            type="number"
+            placeholder="Precio mín"
+            value={state.priceMin ?? ''}
+            onChange={event => update('priceMin', event.target.value ? Number(event.target.value) : undefined)}
+          />
+          <input
+            type="number"
+            placeholder="Precio máx"
+            value={state.priceMax ?? ''}
+            onChange={event => update('priceMax', event.target.value ? Number(event.target.value) : undefined)}
+          />
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+          <input
+            type="number"
+            placeholder="Hab mín"
+            value={state.roomsMin ?? ''}
+            onChange={event => update('roomsMin', event.target.value ? Number(event.target.value) : undefined)}
+          />
+          <input
+            type="number"
+            placeholder="Hab máx"
+            value={state.roomsMax ?? ''}
+            onChange={event => update('roomsMax', event.target.value ? Number(event.target.value) : undefined)}
+          />
+          <input
+            type="number"
+            placeholder="Baños mín"
+            value={state.bathMin ?? ''}
+            onChange={event => update('bathMin', event.target.value ? Number(event.target.value) : undefined)}
+          />
+        </div>
+        <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+          <label>
+            <input type="checkbox" checked={!!state.furnished} onChange={event => update('furnished', event.target.checked)} />
+            {' '}Amueblado
+          </label>
+          <label>
+            <input type="checkbox" checked={!!state.petsAllowed} onChange={event => update('petsAllowed', event.target.checked)} />
+            {' '}Mascotas
+          </label>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+          <select value={state.sort} onChange={event => update('sort', event.target.value as SearchParams['sort'])}>
+            <option value="createdAt">Más recientes</option>
+            <option value="price">Precio</option>
+            <option value="views">Más vistos</option>
+          </select>
+          <select value={state.dir} onChange={event => update('dir', event.target.value as SearchParams['dir'])}>
+            <option value="desc">Desc</option>
+            <option value="asc">Asc</option>
+          </select>
+        </div>
+      </div>
+
+      <button onClick={() => onApply(state)}>Aplicar filtros</button>
+    </div>
+  );
+}

--- a/frontend/src/pages/properties/FavoritesPage.tsx
+++ b/frontend/src/pages/properties/FavoritesPage.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import PropertyCard from '../../components/PropertyCard';
+
+export default function FavoritesPage() {
+  const [items, setItems] = useState<any[]>([]);
+
+  const onFavToggle = (id: string, liked: boolean) => {
+    if (!liked) {
+      setItems(array => array.filter(item => item._id !== id));
+    }
+  };
+
+  return (
+    <div style={{ padding: '24px', display: 'grid', gap: 12 }}>
+      <h2>Mis favoritos</h2>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: 12 }}>
+        {items.map(property => (
+          <PropertyCard key={property._id} p={property} onFavToggle={onFavToggle} />
+        ))}
+        {!items.length && <div>No tienes favoritos aún.</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/properties/PropertiesList.tsx
+++ b/frontend/src/pages/properties/PropertiesList.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import PropertyFilters from '../../components/PropertyFilters';
+import PropertyCard from '../../components/PropertyCard';
+import { favoriteProperty, searchProperties, unfavoriteProperty } from '../../services/properties';
+
+type SearchResponse = {
+  items: any[];
+  page: number;
+  limit: number;
+  total: number;
+};
+
+export default function PropertiesList() {
+  const [params, setParams] = useState<any>({ limit: 12, sort: 'createdAt', dir: 'desc' });
+  const [data, setData] = useState<SearchResponse>({ items: [], page: 1, limit: 12, total: 0 });
+  const [loading, setLoading] = useState(false);
+
+  const load = async (override?: any) => {
+    setLoading(true);
+    const res = await searchProperties({ ...params, ...override });
+    setData(res);
+    setParams((prev: any) => ({ ...prev, ...override, page: res.page }));
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load({ page: 1 });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onApplyFilters = (filters: any) => load({ ...filters, page: 1 });
+
+  const onFavToggle = async (id: string, liked: boolean) => {
+    try {
+      const fn = liked ? favoriteProperty : unfavoriteProperty;
+      await fn(id);
+      setData(current => ({
+        ...current,
+        items: current.items.map(item =>
+          item._id === id
+            ? { ...item, _liked: liked, favoritesCount: (item.favoritesCount || 0) + (liked ? 1 : -1) }
+            : item
+        ),
+      }));
+    } catch (error) {
+      // ignore
+    }
+  };
+
+  const pages = Math.ceil((data.total || 0) / (data.limit || 1)) || 1;
+
+  return (
+    <div style={{ padding: '24px', display: 'grid', gap: 16 }}>
+      <h2>Propiedades</h2>
+      <PropertyFilters initial={params} onApply={onApplyFilters} />
+      {loading && <div>Cargando…</div>}
+      {!loading && (
+        <>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: 12 }}>
+            {data.items.map(property => (
+              <PropertyCard key={property._id} p={property} onFavToggle={onFavToggle} />
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 12 }}>
+            <button disabled={data.page <= 1} onClick={() => load({ page: data.page - 1 })}>
+              Anterior
+            </button>
+            <span>
+              Página {data.page} / {pages}
+            </span>
+            <button disabled={data.page >= pages} onClick={() => load({ page: data.page + 1 })}>
+              Siguiente
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/properties/PropertyDetail.tsx
+++ b/frontend/src/pages/properties/PropertyDetail.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { favoriteProperty, getProperty, incrementView, unfavoriteProperty } from '../../services/properties';
+
+export default function PropertyDetail() {
+  const { id } = useParams();
+  const [property, setProperty] = useState<any>(null);
+  const [liked, setLiked] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      if (!id) return;
+      const detail = await getProperty(id);
+      setProperty(detail);
+      await incrementView(id);
+    })();
+  }, [id]);
+
+  const toggleFavorite = async () => {
+    if (!property?._id) return;
+    if (liked) {
+      await unfavoriteProperty(property._id);
+    } else {
+      await favoriteProperty(property._id);
+    }
+    setLiked(!liked);
+  };
+
+  if (!property) {
+    return <div style={{ padding: 24 }}>Cargando…</div>;
+  }
+
+  const images = property.images?.length ? property.images : ['https://via.placeholder.com/1000x600?text=Property'];
+
+  return (
+    <div style={{ padding: '24px', display: 'grid', gap: 16, maxWidth: 980, margin: '0 auto' }}>
+      <h2>{property.title}</h2>
+      <div style={{ display: 'grid', gap: 8 }}>
+        <img
+          src={images[0]}
+          alt={property.title}
+          style={{ width: '100%', maxHeight: 420, objectFit: 'cover', borderRadius: 10 }}
+        />
+        {images.length > 1 && (
+          <div style={{ display: 'flex', gap: 6, overflowX: 'auto' }}>
+            {images.slice(1).map((src: string, index: number) => (
+              <img key={index} src={src} alt={`${property.title}-${index}`} style={{ height: 90, borderRadius: 6 }} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <div style={{ fontSize: 22, fontWeight: 700 }}>{property.price} € / mes</div>
+          <div style={{ color: '#666' }}>
+            {property.city} · {property.rooms} hab · {property.bathrooms} baños · {property.sizeM2 || '—'} m²
+          </div>
+        </div>
+        <button onClick={toggleFavorite}>{liked ? '❤️ Quitar de favoritos' : '🤍 Añadir a favoritos'}</button>
+      </div>
+
+      <div>
+        <h3>Descripción</h3>
+        <p>{property.description || 'Sin descripción.'}</p>
+      </div>
+
+      <div>
+        <h3>Características</h3>
+        <ul>
+          <li>Mascotas: {property.petsAllowed ? 'Sí' : 'No'}</li>
+          <li>Amueblado: {property.furnished ? 'Sí' : 'No'}</li>
+          <li>
+            Disponible desde: {property.availableFrom ? new Date(property.availableFrom).toLocaleDateString() : '—'}
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/properties.ts
+++ b/frontend/src/services/properties.ts
@@ -3,19 +3,67 @@ import axios from 'axios';
 const API_BASE =
   process.env.REACT_APP_API_URL || process.env.VITE_API_URL || 'http://localhost:3000';
 
+const client = axios.create({
+  baseURL: API_BASE,
+});
+
+export type SearchParams = {
+  q?: string;
+  region?: string;
+  city?: string;
+  priceMin?: number;
+  priceMax?: number;
+  roomsMin?: number;
+  roomsMax?: number;
+  bathMin?: number;
+  furnished?: boolean;
+  petsAllowed?: boolean;
+  availableDate?: string;
+  nearLng?: number;
+  nearLat?: number;
+  maxKm?: number;
+  sort?: 'price' | 'createdAt' | 'views';
+  dir?: 'asc' | 'desc';
+  page?: number;
+  limit?: number;
+};
+
 export const createProperty = async (token: string, data: any) => {
-  const res = await axios.post(`${API_BASE}/api/properties`, data, {
+  const res = await client.post('/api/properties', data, {
     headers: { Authorization: `Bearer ${token}` },
   });
   return res.data;
 };
 
 export const listProperties = async () => {
-  const res = await axios.get(`${API_BASE}/api/properties`);
+  const res = await client.get('/api/properties');
   return res.data;
 };
 
 export const getProperty = async (id: string) => {
-  const res = await axios.get(`${API_BASE}/api/properties/${id}`);
+  const res = await client.get(`/api/properties/${id}`);
   return res.data;
 };
+
+export async function searchProperties(params: SearchParams = {}) {
+  const { data } = await client.get('/api/properties', { params });
+  return data as { items: any[]; page: number; limit: number; total: number };
+}
+
+export async function favoriteProperty(id: string) {
+  const { data } = await client.post(`/api/properties/${id}/favorite`);
+  return data;
+}
+
+export async function unfavoriteProperty(id: string) {
+  const { data } = await client.delete(`/api/properties/${id}/favorite`);
+  return data;
+}
+
+export async function incrementView(id: string) {
+  try {
+    await client.post(`/api/properties/${id}/view`);
+  } catch (error) {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable property filters and cards for listings
- implement paginated property list, detail, and favorites placeholder pages
- extend property services with search, favorite, and view tracking helpers and expose new routes

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ca77d4d788832a8864811701d9e207