### PR TITLE
feat(auth): add guards and role-based layout

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -1,18 +1,95 @@
-import React from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import PropertiesList from './pages/properties/PropertiesList';
-import PropertyDetail from './pages/properties/PropertyDetail';
-import FavoritesPage from './pages/properties/FavoritesPage';
+import React from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { AuthProvider } from "./context/AuthContext";
+import AppLayout from "./components/AppLayout";
+import LoginPage from "./pages/auth/LoginPage";
+import ForbiddenPage from "./pages/system/ForbiddenPage";
+import PropertiesList from "./pages/properties/PropertiesList";
+import PropertyDetail from "./pages/properties/PropertyDetail";
+import FavoritesPage from "./pages/properties/FavoritesPage";
+import ContractWizard from "./pages/contracts/ContractWizard";
+import ProtectedRoute from "./components/ProtectedRoute";
+import RoleGuard from "./components/RoleGuard";
 
 export default function AppRoutes() {
   return (
-    <BrowserRouter>
-      <Routes>
-        {/* ...otras rutas */}
-        <Route path="/properties" element={<PropertiesList />} />
-        <Route path="/properties/:id" element={<PropertyDetail />} />
-        <Route path="/me/favorites" element={<FavoritesPage />} />
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<PropertiesList />} />
+            <Route path="/properties" element={<PropertiesList />} />
+            <Route path="/properties/:id" element={<PropertyDetail />} />
+            <Route
+              path="/contracts"
+              element={
+                <ProtectedRoute>
+                  <RoleGuard roles={["tenant", "landlord", "admin"]}>
+                    <div>Listado de contratos</div>
+                  </RoleGuard>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/me/favorites"
+              element={
+                <ProtectedRoute>
+                  <RoleGuard roles={["tenant", "landlord", "admin"]}>
+                    <FavoritesPage />
+                  </RoleGuard>
+                </ProtectedRoute>
+              }
+            />
+
+            <Route
+              path="/contracts/new"
+              element={
+                <ProtectedRoute>
+                  <RoleGuard roles={["landlord", "admin"]}>
+                    <ContractWizard />
+                  </RoleGuard>
+                </ProtectedRoute>
+              }
+            />
+
+            <Route
+              path="/owner/properties"
+              element={
+                <ProtectedRoute>
+                  <RoleGuard roles={["landlord", "admin"]}>
+                    <div>Panel propietario</div>
+                  </RoleGuard>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/pro/tickets"
+              element={
+                <ProtectedRoute>
+                  <RoleGuard roles={["pro", "admin"]}>
+                    <div>Panel profesional</div>
+                  </RoleGuard>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin"
+              element={
+                <ProtectedRoute>
+                  <RoleGuard roles={["admin"]}>
+                    <div>Panel admin</div>
+                  </RoleGuard>
+                </ProtectedRoute>
+              }
+            />
+
+            <Route path="/403" element={<ForbiddenPage />} />
+            <Route path="*" element={<div style={{ padding: 24 }}>404</div>} />
+          </Route>
+
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   );
 }

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Link, Outlet } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+type NavItemProps = {
+  to: string;
+  children: React.ReactNode;
+};
+
+function NavItem({ to, children }: NavItemProps) {
+  return (
+    <Link to={to} style={{ padding: "8px 12px", borderRadius: 6, textDecoration: "none" }}>
+      {children}
+    </Link>
+  );
+}
+
+export default function AppLayout() {
+  const { user, logout } = useAuth();
+
+  return (
+    <div style={{ display: "grid", gridTemplateRows: "56px 1fr", minHeight: "100vh" }}>
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "0 16px",
+          borderBottom: "1px solid #eee",
+        }}
+      >
+        <Link to="/" style={{ fontWeight: 800, fontSize: 18 }}>
+          RentalApp
+        </Link>
+        <nav style={{ display: "flex", gap: 8, marginLeft: 12 }}>
+          <NavItem to="/properties">Propiedades</NavItem>
+          {user?.role === "tenant" && <NavItem to="/contracts">Mis contratos</NavItem>}
+          {user?.role === "landlord" && (
+            <>
+              <NavItem to="/owner/properties">Mis propiedades</NavItem>
+              <NavItem to="/contracts">Contratos</NavItem>
+            </>
+          )}
+          {user?.role === "pro" && <NavItem to="/pro/tickets">Incidencias</NavItem>}
+          {user?.role === "admin" && <NavItem to="/admin">Admin</NavItem>}
+        </nav>
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 10 }}>
+          {!user && <NavItem to="/login">Entrar</NavItem>}
+          {user && (
+            <>
+              <span style={{ fontSize: 12, opacity: 0.8 }}>
+                {user.email} · {user.role}
+              </span>
+              <button onClick={logout}>Salir</button>
+            </>
+          )}
+        </div>
+      </header>
+      <main style={{ padding: 16 }}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+type Props = {
+  children: JSX.Element;
+};
+
+export default function ProtectedRoute({ children }: Props) {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  if (!user) return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+
+  return children;
+}

--- a/frontend/src/components/RoleGuard.tsx
+++ b/frontend/src/components/RoleGuard.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+type Props = {
+  roles: Array<"tenant" | "landlord" | "pro" | "admin">;
+  children: JSX.Element;
+};
+
+export default function RoleGuard({ roles, children }: Props) {
+  const { user } = useAuth();
+
+  if (!user) return <Navigate to="/login" replace />;
+  if (!roles.includes(user.role)) return <Navigate to="/403" replace />;
+
+  return children;
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,31 +1,23 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import { AuthProvider } from './context/AuthContext';
-import { ThemeProvider } from './context/ThemeContext';
-import { ToastProvider } from './context/ToastContext';
-import reportWebVitals from './reportWebVitals';
-import { BrowserRouter } from 'react-router-dom';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import AppRoutes from "./AppRoutes";
+import { ThemeProvider } from "./context/ThemeContext";
+import { ToastProvider } from "./context/ToastContext";
+import reportWebVitals from "./reportWebVitals";
+import axios from "axios";
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
+axios.defaults.baseURL = process.env.REACT_APP_API_URL || process.env.VITE_API_URL || "";
+
+const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 root.render(
   <React.StrictMode>
     <ThemeProvider>
       <ToastProvider>
-        <AuthProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
-        </AuthProvider>
+        <AppRoutes />
       </ToastProvider>
     </ThemeProvider>
   </React.StrictMode>
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+  const { login } = useAuth();
+  const nav = useNavigate();
+  const loc = useLocation();
+  const next = (loc.state as any)?.from || "/";
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      nav(next, { replace: true });
+    } catch (e: any) {
+      setErr(e?.response?.data?.error || "Error de login");
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      style={{ maxWidth: 360, margin: "64px auto", display: "grid", gap: 12 }}
+    >
+      <h2>Entrar</h2>
+      <input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <input
+        placeholder="Contraseña"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      {err && <div style={{ color: "crimson" }}>{err}</div>}
+      <button type="submit">Acceder</button>
+    </form>
+  );
+}

--- a/frontend/src/pages/system/ForbiddenPage.tsx
+++ b/frontend/src/pages/system/ForbiddenPage.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function ForbiddenPage() {
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>403</h2>
+      <p>No tienes permiso para ver esta página.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the auth service to persist the logged user and bootstrap axios headers
- refresh the AuthContext API with role helpers and expose token-bearing user data
- add protected and role-guarded routes with a shared app layout and simple login/403 pages
- wire the router and entrypoint to use the new layout and guards

## Testing
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ca7a9e79dc832a8cea1fbb093777d8