### PR TITLE
feat(frontend): add tickets ui flows

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -10,6 +10,9 @@ import FavoritesPage from "./pages/properties/FavoritesPage";
 import ContractWizard from "./pages/contracts/ContractWizard";
 import ProtectedRoute from "./components/ProtectedRoute";
 import RoleGuard from "./components/RoleGuard";
+import TicketsList from "./pages/tickets/TicketsList";
+import TicketCreatePage from "./pages/tickets/TicketCreatePage";
+import TicketDetail from "./pages/tickets/TicketDetail";
 
 export default function AppRoutes() {
   return (
@@ -48,6 +51,33 @@ export default function AppRoutes() {
                   <RoleGuard roles={["landlord", "admin"]}>
                     <ContractWizard />
                   </RoleGuard>
+                </ProtectedRoute>
+              }
+            />
+
+            <Route
+              path="/tickets"
+              element={
+                <ProtectedRoute>
+                  <TicketsList />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/tickets/new"
+              element={
+                <ProtectedRoute>
+                  <RoleGuard roles={["tenant", "landlord", "admin"]}>
+                    <TicketCreatePage />
+                  </RoleGuard>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/tickets/:id"
+              element={
+                <ProtectedRoute>
+                  <TicketDetail />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/pages/tickets/TicketCreatePage.tsx
+++ b/frontend/src/pages/tickets/TicketCreatePage.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from "react";
+import { createTicket } from "../../services/tickets";
+
+export default function TicketCreatePage() {
+  const [form, setForm] = useState({
+    contractId: "",
+    service: "plumbing",
+    title: "",
+    description: "",
+  });
+  const [result, setResult] = useState<any>(null);
+
+  const updateField = (key: string, value: any) =>
+    setForm((state) => ({
+      ...state,
+      [key]: value,
+    }));
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const ticket = await createTicket(form);
+    setResult(ticket);
+  };
+
+  return (
+    <div style={{ maxWidth: 520, margin: "24px auto" }}>
+      <h2>Abrir incidencia</h2>
+      <form onSubmit={submit} style={{ display: "grid", gap: 10 }}>
+        <input
+          placeholder="Contract ID"
+          value={form.contractId}
+          onChange={(e) => updateField("contractId", e.target.value)}
+          required
+        />
+        <select
+          value={form.service}
+          onChange={(e) => updateField("service", e.target.value)}
+        >
+          <option value="plumbing">Fontanería</option>
+          <option value="electricity">Electricidad</option>
+          <option value="appliances">Electrodomésticos</option>
+          <option value="painting">Pintura</option>
+        </select>
+        <input
+          placeholder="Título"
+          value={form.title}
+          onChange={(e) => updateField("title", e.target.value)}
+          required
+        />
+        <textarea
+          placeholder="Descripción"
+          value={form.description}
+          onChange={(e) => updateField("description", e.target.value)}
+          rows={5}
+        />
+        <button type="submit">Crear</button>
+      </form>
+      {result && (
+        <pre style={{ background: "#fafafa", padding: 12, marginTop: 12 }}>
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/tickets/TicketDetail.tsx
+++ b/frontend/src/pages/tickets/TicketDetail.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import {
+  getTicket,
+  assignPro,
+  unassignPro,
+  sendQuote,
+  approveQuote,
+  requestExtra,
+  decideExtra,
+  completeWork,
+  closeTicket,
+  openDispute,
+} from "../../services/tickets";
+import { proposeAppointment as proposeAppt } from "../../services/appointments";
+import { searchPros } from "../../services/pros";
+import { useAuth } from "../../context/AuthContext";
+
+export default function TicketDetail() {
+  const { id } = useParams();
+  const { user } = useAuth();
+  const [ticket, setTicket] = useState<any>(null);
+  const [pros, setPros] = useState<any[]>([]);
+  const [amount, setAmount] = useState<number>(0);
+  const [note, setNote] = useState("");
+  const [extraAmount, setExtraAmount] = useState<number>(0);
+  const [extraReason, setExtraReason] = useState("");
+  const [when, setWhen] = useState<string>("");
+
+  const role = user?.role;
+
+  const reload = async () => {
+    if (!id) return;
+    const data = await getTicket(id);
+    setTicket(data);
+  };
+
+  useEffect(() => {
+    reload();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const can = (statuses: string[]) => statuses.includes(ticket?.status);
+
+  const onAssignPro = async (proId: string) => {
+    await assignPro(ticket._id, proId);
+    await reload();
+  };
+
+  const onUnassign = async () => {
+    await unassignPro(ticket._id);
+    await reload();
+  };
+
+  const onSendQuote = async () => {
+    await sendQuote(ticket._id, amount, note);
+    await reload();
+  };
+
+  const onApproveQuote = async () => {
+    await approveQuote(ticket._id);
+    await reload();
+  };
+
+  const onRequestExtra = async () => {
+    await requestExtra(ticket._id, extraAmount, extraReason);
+    await reload();
+  };
+
+  const onDecideExtra = async (decision: "approved" | "rejected") => {
+    await decideExtra(ticket._id, decision);
+    await reload();
+  };
+
+  const onProposeAppt = async () => {
+    await proposeAppt(ticket._id, when);
+    setWhen("");
+    await reload();
+  };
+
+  const onComplete = async () => {
+    await completeWork(ticket._id);
+    await reload();
+  };
+
+  const onClose = async () => {
+    await closeTicket(ticket._id);
+    await reload();
+  };
+
+  const onDispute = async () => {
+    const reason = window.prompt("Motivo de disputa");
+    if (reason) {
+      await openDispute(ticket._id, reason);
+      await reload();
+    }
+  };
+
+  const loadPros = async () => {
+    const list = await searchPros(ticket?.city, ticket?.service);
+    setPros(list.items || []);
+  };
+
+  if (!ticket) return <div style={{ padding: 24 }}>Cargando…</div>;
+
+  return (
+    <div style={{ padding: 24, display: "grid", gap: 12, maxWidth: 920, margin: "0 auto" }}>
+      <h2>
+        Incidencia #{ticket._id.slice(-6)} — {ticket.title}
+      </h2>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <div>
+          <div>
+            <b>Servicio:</b> {ticket.service}
+          </div>
+          <div>
+            <b>Estado:</b> {ticket.status}
+          </div>
+          <div>
+            <b>Propiedad:</b> {ticket.propertyAddress || "—"}
+          </div>
+          <div>
+            <b>Asignado a:</b> {ticket.pro?.displayName || "Sin asignar"}
+          </div>
+          <div>
+            <b>Presupuesto:</b> {ticket.quote?.amount ? `${ticket.quote.amount} €` : "—"}
+          </div>
+          {ticket.extra && (
+            <div>
+              <b>Extra:</b> {ticket.extra.amount} € · {ticket.extra.status}
+            </div>
+          )}
+        </div>
+        <div>
+          <h3>Acciones</h3>
+
+          {role === "landlord" && can(["open", "quoted", "awaiting_schedule"]) && (
+            <div style={{ border: "1px solid #eee", padding: 10, borderRadius: 8, marginBottom: 8 }}>
+              <button onClick={loadPros}>Buscar profesionales</button>
+              <div style={{ display: "grid", gap: 6, marginTop: 8 }}>
+                {pros.map((pro) => (
+                  <div
+                    key={pro._id}
+                    style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
+                  >
+                    <div>
+                      {pro.displayName} · {pro.city} · {(pro.services || []).join(", ")}
+                    </div>
+                    <button onClick={() => onAssignPro(pro._id)}>Asignar</button>
+                  </div>
+                ))}
+                {ticket.pro && <button onClick={onUnassign}>Quitar asignación</button>}
+              </div>
+            </div>
+          )}
+
+          {role === "pro" && can(["open"]) && (
+            <div style={{ border: "1px solid #eee", padding: 10, borderRadius: 8, marginBottom: 8 }}>
+              <div>
+                <b>Enviar presupuesto</b>
+              </div>
+              <input
+                type="number"
+                placeholder="Importe €"
+                value={amount || ""}
+                onChange={(e) => setAmount(Number(e.target.value))}
+              />
+              <input placeholder="Nota" value={note} onChange={(e) => setNote(e.target.value)} />
+              <button onClick={onSendQuote} disabled={!amount}>
+                Enviar
+              </button>
+            </div>
+          )}
+
+          {role === "landlord" && can(["quoted"]) && (
+            <div style={{ border: "1px solid #eee", padding: 10, borderRadius: 8, marginBottom: 8 }}>
+              <div>
+                Presupuesto recibido: <b>{ticket.quote?.amount} €</b>
+              </div>
+              <button onClick={onApproveQuote}>Aprobar y pagar (mock)</button>
+            </div>
+          )}
+
+          {role === "pro" && can(["in_progress", "awaiting_approval"]) && (
+            <div style={{ border: "1px solid #eee", padding: 10, borderRadius: 8, marginBottom: 8 }}>
+              <div>
+                <b>Solicitar extra</b>
+              </div>
+              <input
+                type="number"
+                placeholder="Importe extra €"
+                value={extraAmount || ""}
+                onChange={(e) => setExtraAmount(Number(e.target.value))}
+              />
+              <input placeholder="Motivo" value={extraReason} onChange={(e) => setExtraReason(e.target.value)} />
+              <button onClick={onRequestExtra} disabled={!extraAmount || !extraReason}>
+                Enviar
+              </button>
+            </div>
+          )}
+
+          {role === "landlord" && ticket.extra?.status === "pending" && (
+            <div style={{ border: "1px solid #eee", padding: 10, borderRadius: 8, marginBottom: 8 }}>
+              <div>
+                Extra solicitado: <b>{ticket.extra.amount} €</b> — {ticket.extra.reason}
+              </div>
+              <button onClick={() => onDecideExtra("approved")}>Aprobar</button>
+              <button onClick={() => onDecideExtra("rejected")}>Rechazar</button>
+            </div>
+          )}
+
+          {(role === "pro" || role === "landlord" || role === "tenant") &&
+            can(["quoted", "awaiting_schedule", "in_progress"]) && (
+              <div style={{ border: "1px solid #eee", padding: 10, borderRadius: 8, marginBottom: 8 }}>
+                <div>
+                  <b>Proponer cita</b>
+                </div>
+                <input type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)} />
+                <button onClick={onProposeAppt} disabled={!when}>
+                  Proponer
+                </button>
+              </div>
+            )}
+
+          {role === "pro" && can(["in_progress"]) && (
+            <div style={{ border: "1px solid #eee", padding: 10, borderRadius: 8, marginBottom: 8 }}>
+              <button onClick={onComplete}>Trabajo completado</button>
+            </div>
+          )}
+
+          {(role === "landlord" || role === "tenant") && can(["done"]) && (
+            <div style={{ border: "1px solid #eee", padding: 10, borderRadius: 8, marginBottom: 8 }}>
+              <button onClick={onClose}>Cerrar incidencia</button>
+              <button onClick={onDispute}>Abrir disputa</button>
+            </div>
+          )}
+        </div>
+      </div>
+      <div>
+        <h3>Descripción</h3>
+        <p>{ticket.description || "—"}</p>
+      </div>
+      {ticket.history?.length ? (
+        <div>
+          <h3>Historial</h3>
+          <ul>
+            {ticket.history.map((item: any, index: number) => (
+              <li key={index}>
+                {item.action} — {new Date(item.ts || item.date || Date.now()).toLocaleString()}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/tickets/TicketsList.tsx
+++ b/frontend/src/pages/tickets/TicketsList.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { listMyTickets } from "../../services/tickets";
+import { useAuth } from "../../context/AuthContext";
+
+export default function TicketsList() {
+  const { user } = useAuth();
+  const role = user?.role === "pro" ? "pro" : user?.role === "landlord" ? "landlord" : "tenant";
+  const [data, setData] = useState<{ items: any[]; page: number; total: number }>({ items: [], page: 1, total: 0 });
+
+  const load = async (page = 1) => {
+    const res = await listMyTickets(role as "tenant" | "landlord" | "pro", { page });
+    setData(res);
+  };
+
+  useEffect(() => {
+    load(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>Incidencias ({role})</h2>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Título</th>
+            <th>Servicio</th>
+            <th>Estado</th>
+            <th>Actualizado</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.items.map((ticket) => (
+            <tr key={ticket._id} style={{ borderTop: "1px solid #eee" }}>
+              <td>{ticket._id.slice(-6)}</td>
+              <td>{ticket.title}</td>
+              <td>{ticket.service}</td>
+              <td>{ticket.status}</td>
+              <td>{new Date(ticket.updatedAt).toLocaleString()}</td>
+              <td>
+                <Link to={`/tickets/${ticket._id}`}>Ver</Link>
+              </td>
+            </tr>
+          ))}
+          {!data.items.length && (
+            <tr>
+              <td colSpan={6} style={{ padding: 12 }}>
+                No hay incidencias.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/services/appointments.ts
+++ b/frontend/src/services/appointments.ts
@@ -1,0 +1,16 @@
+import axios from "axios";
+
+export async function proposeAppointment(ticketId: string, whenIso: string) {
+  const { data } = await axios.post(`/api/appointments/${ticketId}/propose`, { when: whenIso });
+  return data;
+}
+
+export async function confirmAppointment(appointmentId: string) {
+  const { data } = await axios.post(`/api/appointments/${appointmentId}/confirm`);
+  return data;
+}
+
+export async function rejectAppointment(appointmentId: string, reason?: string) {
+  const { data } = await axios.post(`/api/appointments/${appointmentId}/reject`, { reason });
+  return data;
+}

--- a/frontend/src/services/pros.ts
+++ b/frontend/src/services/pros.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export async function searchPros(city?: string, service?: string) {
+  const { data } = await axios.get("/api/pros", { params: { city, service } });
+  return data as { items: any[] };
+}

--- a/frontend/src/services/tickets.ts
+++ b/frontend/src/services/tickets.ts
@@ -1,0 +1,69 @@
+import axios from "axios";
+
+export type TicketRole = "tenant" | "landlord" | "pro";
+
+export async function createTicket(payload: Record<string, unknown>) {
+  const { data } = await axios.post("/api/tickets", payload);
+  return data;
+}
+
+export async function getTicket(id: string) {
+  const { data } = await axios.get(`/api/tickets/${id}`);
+  return data;
+}
+
+export async function listMyTickets(role: TicketRole, params: Record<string, unknown> = {}) {
+  const path =
+    role === "tenant"
+      ? "/api/tickets/mine/tenant"
+      : role === "landlord"
+        ? "/api/tickets/mine/owner"
+        : "/api/tickets/mine/pro";
+  const { data } = await axios.get(path, { params });
+  return data as { items: any[]; page: number; total: number };
+}
+
+export async function assignPro(id: string, proId: string) {
+  const { data } = await axios.post(`/api/tickets/${id}/assign`, { proId });
+  return data;
+}
+
+export async function unassignPro(id: string) {
+  const { data } = await axios.post(`/api/tickets/${id}/unassign`);
+  return data;
+}
+
+export async function sendQuote(id: string, amount: number, note?: string) {
+  const { data } = await axios.post(`/api/tickets/${id}/quote`, { amount, note });
+  return data;
+}
+
+export async function approveQuote(id: string) {
+  const { data } = await axios.post(`/api/tickets/${id}/approve`);
+  return data;
+}
+
+export async function requestExtra(id: string, amount: number, reason: string) {
+  const { data } = await axios.post(`/api/tickets/${id}/extra`, { amount, reason });
+  return data;
+}
+
+export async function decideExtra(id: string, decision: "approved" | "rejected") {
+  const { data } = await axios.post(`/api/tickets/${id}/extra/decide`, { decision });
+  return data;
+}
+
+export async function completeWork(id: string, invoiceUrl?: string) {
+  const { data } = await axios.post(`/api/tickets/${id}/complete`, { invoiceUrl });
+  return data;
+}
+
+export async function closeTicket(id: string) {
+  const { data } = await axios.post(`/api/tickets/${id}/close`);
+  return data;
+}
+
+export async function openDispute(id: string, reason: string) {
+  const { data } = await axios.post(`/api/tickets/${id}/dispute`, { reason });
+  return data;
+}


### PR DESCRIPTION
## Summary
- add tickets, appointments, and pros service clients to talk to the API
- implement tenant/landlord/pro ticket create, list, and detail management screens
- register the new ticket pages in the router

## Testing
- `npm run test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68caa876c518832ab9c5ba65bb92d291