### PR TITLE
feat: add password reset flow

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -3,6 +3,8 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
 import AppLayout from "./components/AppLayout";
 import LoginPage from "./pages/auth/LoginPage";
+import ForgotPassword from "./pages/auth/ForgotPassword";
+import ResetPassword from "./pages/auth/ResetPassword";
 import ForbiddenPage from "./pages/system/ForbiddenPage";
 import PropertiesList from "./pages/properties/PropertiesList";
 import PropertyDetail from "./pages/properties/PropertyDetail";
@@ -118,6 +120,8 @@ export default function AppRoutes() {
           </Route>
 
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+          <Route path="/reset" element={<ResetPassword />} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import axios from "axios";
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: 360,
+  margin: "64px auto",
+  padding: 24,
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  background: "#fff",
+};
+
+const buttonStyle: React.CSSProperties = {
+  width: "100%",
+  marginTop: 16,
+  padding: "10px 16px",
+  backgroundColor: "#1890ff",
+  color: "#fff",
+  border: "none",
+  borderRadius: 4,
+  cursor: "pointer",
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 12px",
+  marginTop: 8,
+  border: "1px solid #ccc",
+  borderRadius: 4,
+};
+
+const messageStyle: React.CSSProperties = {
+  marginTop: 16,
+  fontSize: 14,
+};
+
+const ForgotPassword: React.FC = () => {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setStatus("idle");
+    try {
+      await axios.post("/api/auth/request-reset", { email });
+      setStatus("success");
+    } catch (error) {
+      console.error("Error requesting password reset", error);
+      setStatus("error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={containerStyle}>
+      <h2>Recuperar contraseña</h2>
+      <form onSubmit={handleSubmit}>
+        <label htmlFor="email">Correo electrónico</label>
+        <input
+          id="email"
+          type="email"
+          required
+          value={email}
+          onChange={event => setEmail(event.target.value)}
+          style={inputStyle}
+        />
+        <button type="submit" style={buttonStyle} disabled={loading}>
+          {loading ? "Enviando..." : "Enviar enlace"}
+        </button>
+      </form>
+      {status === "success" && (
+        <p style={{ ...messageStyle, color: "#389e0d" }}>
+          Si el email existe, recibirás un link para restablecer tu contraseña.
+        </p>
+      )}
+      {status === "error" && (
+        <p style={{ ...messageStyle, color: "#cf1322" }}>
+          Ha ocurrido un error al solicitar el reseteo. Inténtalo de nuevo más tarde.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/frontend/src/pages/auth/ResetPassword.tsx
+++ b/frontend/src/pages/auth/ResetPassword.tsx
@@ -1,0 +1,98 @@
+import React, { useMemo, useState } from "react";
+import axios from "axios";
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: 360,
+  margin: "64px auto",
+  padding: 24,
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  background: "#fff",
+};
+
+const buttonStyle: React.CSSProperties = {
+  width: "100%",
+  marginTop: 16,
+  padding: "10px 16px",
+  backgroundColor: "#1890ff",
+  color: "#fff",
+  border: "none",
+  borderRadius: 4,
+  cursor: "pointer",
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 12px",
+  marginTop: 8,
+  border: "1px solid #ccc",
+  borderRadius: 4,
+};
+
+const messageStyle: React.CSSProperties = {
+  marginTop: 16,
+  fontSize: 14,
+};
+
+const ResetPassword: React.FC = () => {
+  const token = useMemo(() => new URLSearchParams(window.location.search).get("token") || "", []);
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!token) {
+      setStatus("error");
+      setErrorMessage("Token no válido. Revisa el enlace de recuperación.");
+      return;
+    }
+    setLoading(true);
+    setStatus("idle");
+    setErrorMessage("");
+    try {
+      await axios.post("/api/auth/reset", { token, password });
+      setStatus("success");
+    } catch (error: any) {
+      console.error("Error resetting password", error);
+      const message =
+        error?.response?.data?.error || "No se pudo restablecer la contraseña. Inténtalo más tarde.";
+      setErrorMessage(message);
+      setStatus("error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={containerStyle}>
+      <h2>Restablecer contraseña</h2>
+      <form onSubmit={handleSubmit}>
+        <label htmlFor="password">Nueva contraseña</label>
+        <input
+          id="password"
+          type="password"
+          required
+          minLength={6}
+          value={password}
+          onChange={event => setPassword(event.target.value)}
+          style={inputStyle}
+        />
+        <button type="submit" style={buttonStyle} disabled={loading}>
+          {loading ? "Guardando..." : "Cambiar contraseña"}
+        </button>
+      </form>
+      {status === "success" && (
+        <p style={{ ...messageStyle, color: "#389e0d" }}>
+          Tu contraseña se ha actualizado correctamente. Ya puedes iniciar sesión con la nueva clave.
+        </p>
+      )}
+      {status === "error" && (
+        <p style={{ ...messageStyle, color: "#cf1322" }}>{errorMessage || "Error al restablecer la contraseña."}</p>
+      )}
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -29,6 +29,9 @@ const userSchema = new Schema(
     // Optional Stripe identifiers for payments
     stripeAccountId: { type: String },
     stripeCustomerId: { type: String },
+    // Password reset support
+    resetToken: { type: String },
+    resetTokenExp: { type: Date },
   },
   { timestamps: true },
 );

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { body } from 'express-validator';
-import { register, login } from '../controllers/auth.controller';
+import { register, login, requestPasswordReset, resetPassword } from '../controllers/auth.controller';
 import { validate } from '../middleware/validate';
 import { asyncHandler } from '../utils/asyncHandler';
 
@@ -21,5 +21,17 @@ router.post(
   [body('email').isEmail(), body('password').isString().notEmpty()],
   validate,
   asyncHandler(login),
+);
+router.post(
+  '/request-reset',
+  [body('email').isEmail()],
+  validate,
+  asyncHandler(requestPasswordReset),
+);
+router.post(
+  '/reset',
+  [body('token').isString().notEmpty(), body('password').isLength({ min: 6 })],
+  validate,
+  asyncHandler(resetPassword),
 );
 export default router;

--- a/tests/auth/reset.test.ts
+++ b/tests/auth/reset.test.ts
@@ -1,0 +1,95 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import type { MongoMemoryServer } from 'mongodb-memory-server';
+import bcrypt from 'bcryptjs';
+import { startMongoMemoryServer } from '../../src/__tests__/utils/mongoMemoryServer';
+import { User } from '../../src/models/user.model';
+
+let app: any;
+let mongo: MongoMemoryServer | undefined;
+
+beforeAll(async () => {
+  mongo = await startMongoMemoryServer();
+  process.env.MONGO_URL = mongo.getUri();
+  process.env.NODE_ENV = 'test';
+  const mod = await import('../../src/app');
+  app = mod.app || mod.default;
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+  if (mongo) await mongo.stop();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+});
+
+describe('Password reset flow', () => {
+  it('request-reset devuelve 200 aunque el email no exista', async () => {
+    const res = await request(app).post('/api/auth/request-reset').send({ email: 'ghost@example.com' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('genera token y expiración para un usuario existente', async () => {
+    const passwordHash = await bcrypt.hash('password123', 10);
+    const user = await User.create({
+      name: 'Test User',
+      email: 'test@example.com',
+      passwordHash,
+      role: 'tenant',
+    });
+
+    const res = await request(app).post('/api/auth/request-reset').send({ email: user.email });
+    expect(res.status).toBe(200);
+
+    const updated = await User.findById(user._id);
+    expect(updated?.resetToken).toBeDefined();
+    expect(updated?.resetTokenExp).toBeInstanceOf(Date);
+    expect(updated!.resetTokenExp!.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('permite cambiar la contraseña con un token válido', async () => {
+    const passwordHash = await bcrypt.hash('oldpassword', 10);
+    const user = await User.create({
+      name: 'Reset User',
+      email: 'reset@example.com',
+      passwordHash,
+      role: 'tenant',
+    });
+    user.resetToken = 'validtoken';
+    user.resetTokenExp = new Date(Date.now() + 60 * 60 * 1000);
+    await user.save();
+
+    const res = await request(app)
+      .post('/api/auth/reset')
+      .send({ token: 'validtoken', password: 'newpassword' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+
+    const updated = await User.findById(user._id);
+    expect(updated?.resetToken).toBeFalsy();
+    expect(updated?.resetTokenExp).toBeFalsy();
+    expect(await bcrypt.compare('newpassword', updated!.passwordHash)).toBe(true);
+  });
+
+  it('rechaza tokens inválidos o expirados', async () => {
+    const passwordHash = await bcrypt.hash('anotherpassword', 10);
+    const user = await User.create({
+      name: 'Expired User',
+      email: 'expired@example.com',
+      passwordHash,
+      role: 'tenant',
+    });
+    user.resetToken = 'expiredtoken';
+    user.resetTokenExp = new Date(Date.now() - 1000);
+    await user.save();
+
+    const res = await request(app)
+      .post('/api/auth/reset')
+      .send({ token: 'expiredtoken', password: 'newpass' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add reset token fields and controller endpoints to support password reset
- send mock emails with reset links and cover flow with integration tests
- add React pages for requesting and completing password resets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caab5cbcf4832a83c6195ce9054fdb